### PR TITLE
Fix weird history problems

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,7 +50,6 @@ function showItemByUrl(frag) {
     hideAll();
     el.style.display = 'block';
     el.classList.remove('small');
-    el.classList.add('show');
     back.classList.add('show');
   }
 }


### PR DESCRIPTION
There were some problems introduced in 44df46e009fc4c9f9271d7ed0143a88480f4971d that made history work very weirdly when using the browser's back button. I couldn't figure out exactly what was going wrong, and, as I've experienced lots of confusing behavior with `pushState` in the past, I decided to just use `hashchange` since we're only doing stuff with window hashes (the latter also has wider browser support).

Unfortunately this is also mixed in with a bunch of other random changes... Sorry about that.
