### PR TITLE
Fix inconsistent spelling of JavaScript within the index.html page

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
       </div>
       <div class="box orange" data-url="asyncyou">
         <h2 class="title">
-              async You
+              Async You
         </h2>
         <div class="screenshot">
           <img src="images/asyncyou.png" alt="">


### PR DESCRIPTION
Across the site, JavaScript was spelled as "javascript", "Javascript" or "JavaScript" (correct spelling, as you're well aware). So I just took the liberty of correcting these for you! 

Cheers
