### PR TITLE
Fix link for goingnative

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
           An exploration of Node.js from the underside: native C++ add-ons
         </p>
         <div class="expanded">
-          <a href="https://github.com/tableflip/nodebot-workshop"
+          <a href="https://github.com/rvagg/goingnative"
              class="view-source">view-source</a>
           Once you have <a href="http://nodejs.org">node</a> installed, open cmd.exe or Terminal.app and run:
           <pre>npm install -g goingnative</pre>


### PR DESCRIPTION
Just noticed a typo that probably stems from copy-pasting from the previous workshop metadata.

This fixes that rather minor typo :)
