### PR TITLE
Add ids to .workshopper divs, reformat some html

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,42 +169,42 @@
           <p>Learn fundamental functional programming features of JavaScript in vanilla ES5.</p>
           <code>npm install -g functional-javascript-workshop</code>
         </div>
-        <div class="workshopper">
+        <div id="levelmeup" class="workshopper">
           <h2><a href="https://github.com/rvagg/levelmeup" target="_blank">Level Me Up Scotty!</a></h2>
           <p>Learn to use leveldb, a simple key/value store with a vibrant package.</p>
           <code>npm install -g levelmeup</code>
         </div>
-        <div class="workshopper">
+        <div id="expressworks" class="workshopper">
           <h2><a href="https://github.com/azat-co/expressworks" target="_blank">ExpressWorks</a></h2>
           <p>Learn the basics of the Express.js framework.</p>
           <code>npm install -g expressworks</code>
         </div>
-        <div class="workshopper">
+        <div id="makemehapi" class="workshopper">
           <h2><a href="https://github.com/spumko/makemehapi" target="_blank">Make Me Hapi</a></h2>
           <p>Learn all about hapi through a series of challenges.</p>
           <code>npm install -g makemehapi</code>
         </div>
-        <div class="workshopper">
+        <div id="promiseitwonthurt" class="workshopper">
           <h2><a href="https://github.com/stevekane/promise-it-wont-hurt" target="_blank">Promise It Won't Hurt</a></h2>
           <p>Learn to use promises in JavaScript to handle async operations.</p>
           <code>npm install -g promise-it-wont-hurt</code>
         </div>
-        <div class="workshopper">
+        <div id="asyncyou" class="workshopper">
           <h2><a href="https://github.com/bulkan/async-you" target="_blank">Async You</a></h2>
           <p>Learn to use the async package.</p>
           <code>npm install -g async-you</code>
         </div>
-        <div class="workshopper">
+        <div id="nodebot" class="workshopper">
           <h2><a href="https://github.com/tableflip/nodebot-workshop" target="_blank">NodeBot Workshop</a></h2>
           <p>Make robots with the johnny-five api.</p>
           <code>npm install -g nodebot-workshop</code>
         </div>
-        <div class="workshopper">
+        <div id="goingnative" class="workshopper">
           <h2><a href="https://github.com/rvagg/goingnative" target="_blank">Going Native</a></h2>
           <p>An exploration of Node.js from the underside: native C++ add-ons.</p>
           <code>npm install -g goingnative</code>
         </div>
-        <div class="workshopper">
+        <div id="planetproto" class="workshopper">
           <h2><a href="https://github.com/sporto/planetproto" target="_blank">Planet Proto</a></h2>
           <p>Understanding JavaScript Prototypes</p>
           <code>npm install -g planetproto</code>
@@ -212,7 +212,7 @@
       </div>
 
       <div class="third">
-        <div class="workshopper">
+        <div id="shader-school" class="workshopper">
           <h2><a href="https://github.com/gl-modules/shader-school" target="_blank">Shader School</a></h2>
           <p>Learn the fundamentals of graphics programming using GLSL shaders.</p>
           <code>npm install -g shader-school</code>
@@ -222,36 +222,36 @@
           <p>Learn how to manipulate binary data in node.js and HTML5 browsers.</p>
           <code>npm install -g bytewiser</code>
         </div>
-        <div class="workshopper">
+        <div id="bug-clinic" class="workshopper">
           <h2><a href="https://github.com/othiym23/bug-clinic" target="_blank">Bug Clinic</a></h2>
           <p>Learn some new tools and techniques as you improve your debugging skills.</p>
           <code>npm install -g bug-clinic</code>
         </div>
-        <div class="workshopper">
+        <div id="browserify-adventure" class="workshopper">
           <h2><a href="https://github.com/substack/browserify-adventure" target="_blank">Browserify Adventure</a></h2>
           <p>Use npm modules and node-style require() in the browser with browserify.</p>
           <code>npm install -g browserify-adventure</code>
         </div>
-        <div class="workshopper">
+        <div id="intro-to-webgl" class="workshopper">
           <h2><a href="https://github.com/alexmackey/IntroToWebGLWithThreeJS" target="_blank">Intro to WebGL</a></h2>
           <p>Get started with three.js and WebGL.</p>
           <code>npm install -g introtowebgl</code>
         </div>
-        <div class="workshopper">
+        <div id="count-to-6" class="workshopper">
           <h2><a href="https://github.com/domenic/count-to-6" target="_blank">Count to 6</a></h2>
           <p>Learn how to use some features from ES6, the next version of JavaScript.</p>
           <code>npm install -g count-to-6</code>
         </div>
-      <div class="workshopper">
-        <h2><a href="https://github.com/koajs/kick-off-koa" target="_blank">Kick off Koa</a></h2>
-        <p>Getting start with Koa, the next generation web framework for Node.js.</p>
-        <code>npm install -g kick-off-koa</code>
-      </div>
-      <div class="workshopper">
-        <h2><a href="https://github.com/mdunisch/lololodash" target="_blank">LololoDash</a></h2>
-        <p>Learn Lo-Dash (fork of underscore) to handle your arrays and objects simple!</p>
-        <code>npm install -g lololodash</code>
-      </div>
+        <div id="kick-off-koa" class="workshopper">
+          <h2><a href="https://github.com/koajs/kick-off-koa" target="_blank">Kick off Koa</a></h2>
+          <p>Getting start with Koa, the next generation web framework for Node.js.</p>
+          <code>npm install -g kick-off-koa</code>
+        </div>
+        <div id="lololodash" class="workshopper">
+          <h2><a href="https://github.com/mdunisch/lololodash" target="_blank">LololoDash</a></h2>
+          <p>Learn Lo-Dash (fork of underscore) to handle your arrays and objects simple!</p>
+          <code>npm install -g lololodash</code>
+        </div>
 
       </div>
     </div>


### PR DESCRIPTION
This PR will add the ability to link to separate workshops. Yes, this functionality won't highlight needed workshop as distinct as it was in previous version of site, but it's a place to start. Further improvements might be done using `:target` pseudoclass.
ids were taken from [old data-urls](https://github.com/nodeschool/nodeschool.github.io/blob/0e1cd46db88c7716bd55a3894232387df4e17bfd/index.html) so that all old links people might have in slides/github will probably work (btw, current ids for learnyounode, streamadventure divs are different from previous verions). This PR also fixes formatting for 2 divs to be as for all other .worskhopper divs.
