### PR TITLE
Improve readability of multi-day events

### DIFF
--- a/events.css
+++ b/events.css
@@ -125,6 +125,9 @@ a:hover {
   border-color: #F7DA03;
   border-bottom-width: 2px;
 }
+.multi-days a {
+  color: #EEE;
+}
 .event a:hover {
   color: #F7DA03;
 }


### PR DESCRIPTION
Multiday events appear essentially as black text on a black background.

![image](https://cloud.githubusercontent.com/assets/357481/4477116/76fd9294-497b-11e4-9f89-8a3783af75dc.png)

This changes the text color for multiday events to nearly white on the same black background. Hover color is not changed.

![image](https://cloud.githubusercontent.com/assets/357481/4477129/9b9f9b38-497b-11e4-8044-a013f7349c1f.png)
