### PR TITLE
Add jekyll's _site to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+_site


### PR DESCRIPTION
In case someone will be running jekyll on localhost so that it doesn't get into repo.
