### PR TITLE
Make the language generator script executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "browserify -r xhr -r browser-locale -r run-parallel > js/dependencies.js",
-    "language": "node scripts/generate_lang.js"
+    "language": "./scripts/generate_lang.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate_lang.js
+++ b/scripts/generate_lang.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var fs = require('fs');
 var path = require('path');
 var cheerio = require('cheerio');


### PR DESCRIPTION
Some exotic installations don't have a `node` executable
