### PR TITLE
add learnuv workshop

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,6 +276,11 @@
           <p data-i18n="workshopper-learnyoucouchdb">Learn about CouchDB - the database that completely embraces the web</p>
           <code>npm install -g learnyoucouchdb</code>
         </div>
+        <div id="learnuv" class="workshopper">
+          <h2><a href="https://github.com/thlorenz/learnuv" target="_blank">learnuv</a></h2>
+          <p data-i18n="workshopper-learnuv">Learn uv for fun and profit, a self guided workshop to the library that powers Node.js.</p>
+          <code>git clone https://github.com/thlorenz/learnuv.git &amp;&amp; cd learnuv &amp;&amp; npm install</code>
+        </div>
 
         </div>
       </div>


### PR DESCRIPTION
- note that the installation step is a bit different from other workshoppers since users need to clone the repo and run `npm install` locally
- this is because [learnuv](https://github.com/thlorenz/learnuv) is setting up a build script besides cloning dependencies like libuv
