### PR TITLE
Fixed events calendar links

### DIFF
--- a/events.html
+++ b/events.html
@@ -84,7 +84,7 @@
     <script id="events" type="text/html">
       <ul>
         {{#rows}}
-          <li>{{startdate}} <a href="{{tickets}}">{{name}}</a></li>
+          <li>{{startdate}} <a href="{{website}}">{{name}}</a></li>
         {{/rows}}
           <li><a href="events.html">See all events</a></li>
       </ul>

--- a/js/table.js
+++ b/js/table.js
@@ -40,7 +40,7 @@ function addMonthMenu() {
 function appendEvent( event ) {
   eventStartDate = new Date(event.startdate)
   eventEndDate   = new Date(event.enddate)
-  eventElement   = $('<div class="event"><a target="_blank" href="' + event.tickets + '" title="' + event.name + '">' + event.name + '</a></div>')
+  eventElement   = $('<div class="event"><a target="_blank" href="' + event.website + '" title="' + event.name + '">' + event.name + '</a></div>')
 
   // Handle multi-days
   if( eventEndDate.getDate() ) {
@@ -64,7 +64,7 @@ function appendEvent( event ) {
         dateElement.append('<div class="event spacer">&nbsp;</div>')
       })
 
-      dateElement.removeClass('no-event').append('<div class="event multi-days following-days" title="' + event.name + '"><a target="_blank" href="' + event.tickets + '">' + event.name + '</a></div>')
+      dateElement.removeClass('no-event').append('<div class="event multi-days following-days" title="' + event.name + '"><a target="_blank" href="' + event.website + '">' + event.name + '</a></div>')
     }
   }
 


### PR DESCRIPTION
Fixed issue #173 regarding broken links in the events calendar.

The links were fetched from a non existing column named "tickets" from the events spreadsheet. Fixed to fetch links from the "website" column instead.
