### PR TITLE
Fix calendar month order

### DIFF
--- a/js/table.js
+++ b/js/table.js
@@ -78,7 +78,6 @@ function generateAllTheMonths( eventData ) {
   dates  = dates.sort(function (a, b) { return a - b })
   months = []
   $.each( dates, function(_, date) {
-    date = new Date(date)
     if( months.indexOf(date.getMonth()) < 0 ) {
       months.push(date.getMonth())
       generateMonthTable(date)


### PR DESCRIPTION
This pull request attemps to fix the following bug in the order of the months for the calendar of the nodeschool events page:

![image](https://cloud.githubusercontent.com/assets/2078803/5637380/03e161b8-95da-11e4-8e7b-2c61b2d16b90.png)

As you see, it shows Jan, Apr, Mar, Feb
