### PR TITLE
update video link

### DIFF
--- a/about.html
+++ b/about.html
@@ -78,7 +78,7 @@
           <h3 data-i18n="about-header-talk-title">Hear and see people talk</h3>
         </div>
         <div class="two-thirds">
-          <p data-i18n="about-info3">In <a href="https://archive.org/details/NodeUp55" target="_blank">episode 55</a> of the NodeUp podcast Mikeal Rogers, Max Ogden and other community members talk about NodeSchools. At Cascadia JS 2014 Jason Rhodes, from Baltimore, <a href="https://www.youtube.com/watch?v=XsmvTnOLwhk" target="_blank">talks about running NodeSchools</a>.</p>
+          <p data-i18n="about-info3">In <a href="https://archive.org/details/NodeUp55" target="_blank">episode 55</a> of the NodeUp podcast Mikeal Rogers, Max Ogden and other community members talk about NodeSchools. At Cascadia JS 2014 Jason Rhodes, from Baltimore, <a href="https://www.youtube.com/watch?v=YJ7txKTh3-E" target="_blank">talks about running NodeSchools</a>.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The YouTube link for Jason Rhodes's talk is a private video. There is another version on YouTube that is publicly viewable. This pull request updates the link to that public link.