### PR TITLE
update lang in html element attribute rather than body

### DIFF
--- a/js/lang.js
+++ b/js/lang.js
@@ -28,7 +28,7 @@ function translate(languages, i18nSpecifiers) {
 
   if (!lang) {
     lang = "en"
-    $(document.body).attr("data-lang", 'en')
+    $('html').attr("lang", 'en')
   }
   
   translateToLang(lang, languages, i18nSpecifiers)
@@ -42,12 +42,12 @@ function resetLang() {
 function translateToLang(lang, languages, i18nSpecifiers) {
   addTranslationNav(lang, languages)
 
-  if (lang === $(document.body).attr("data-lang")) return
+  if (lang === $('html').attr("lang")) return
   if (lang === 'en') return resetLang()
   
   xhr({url: 'languages/' + lang + '.json', json: true}, function(err, resp, keys) {
     if (err) return console.error('Could not fetch translation json for', lang)
-    $(document.body).attr("data-lang", lang)
+    $('html').attr("lang", lang)
     localStorage.setItem('lang', lang)  
     translateHTML(lang, keys, i18nSpecifiers)
   })


### PR DESCRIPTION
The current code tracks the language code with a `data-lang` attribute on the `body` element.

For accessibility purposes, the language code should be in the `lang` attribute of the `html` element. (See http://www.w3.org/TR/WCAG20-TECHS/H57.html for details.) So this pull request moves it there.

Pre-emptive strike: Yes, ideally, the attribute should be in the static document source and not inserted dynamically with JavaScript. However, we don't have a choice here (short of rendering a different file for each language, which may not be a terrible solution actually) because there is no dynamic server side rendering. Yes, screen-readers etc. that do not handle JavaScript will not see the `lang` attribute. However, there are certainly screen-readers that do handle JavaScript, and the ratio of those that do handle JavaScript to those that don't is only going up.