### PR TITLE
rm confusing alt text

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <header>
       <div class="container">
         <div class="full">
-          <img src="images/schoolhouse.svg" alt="nodeschoolhouse">
+          <img src="images/schoolhouse.svg" alt="">
           <h1 class="name">
             <span>NODE</span>
             <span class="apostrophe"></span>


### PR DESCRIPTION
The alt text "nodeschoolhouse" is unintelligible to screen readers and probably other assistive technology. Since the purpose of alt text is to provide the information that would be missing in situations where the image is not available (e.g., someone using a screen reader), this particular alt text should be blank as the image is mostly decorative.