### PR TITLE
replace value attribute with content attribute

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,7 +2,7 @@
 <html class="about">
   <head>
     <meta charset="utf-8">
-    <meta name="google" value="notranslate" />
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="style.css">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">

--- a/building-workshops.html
+++ b/building-workshops.html
@@ -2,7 +2,7 @@
 <html class="building-workshops">
   <head>
     <meta charset="utf-8">
-    <meta name="google" value="notranslate" />
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="style.css">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">

--- a/chapters.html
+++ b/chapters.html
@@ -2,7 +2,7 @@
 <html class="chapters">
   <head>
     <meta charset="utf-8">
-    <meta name="google" value="notranslate" />
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chapters.css">
     <link rel="shortcut icon" href="favicon.ico">

--- a/events.html
+++ b/events.html
@@ -2,7 +2,7 @@
 <html class="events">
   <head>
     <meta charset="utf-8">
-    <meta name="google" value="notranslate" />
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="mapbox.css">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="events.css">

--- a/hexdex.html
+++ b/hexdex.html
@@ -2,7 +2,7 @@
 <html class="chapters">
   <head>
     <meta charset="utf-8">
-    <meta name="google" value="notranslate" />
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chapters.css">
     <link rel="shortcut icon" href="favicon.ico">

--- a/host.html
+++ b/host.html
@@ -2,7 +2,7 @@
 <html class="host">
   <head>
     <meta charset="utf-8">
-    <meta name="google" value="notranslate" />
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="style.css">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html class="index" lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="google" value="notranslate" />
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="mapbox.css">
     <link rel="stylesheet" href="style.css">
     <link rel="shortcut icon" href="favicon.ico">


### PR DESCRIPTION
The `meta notranslate` tag on the NodeSchool site is used to control the translation behavior of Google's search results page. Per [Google documentation](https://support.google.com/webmasters/answer/79812?hl=en) the correct markdown for the `meta notranslate` tag uses a `content` attribute and not a `value` attribute.

This has the added minor benefit of being valid HTML5 whereas the use of a `value` attribute on the `meta` tag is not. (I only noticed this issue because I ran the site through the W3C validator.)