### PR TITLE
Fix event calendar

### DIFF
--- a/events.css
+++ b/events.css
@@ -60,7 +60,7 @@
   border: 0;
   font-weight: bold;
   text-transform: uppercase;
-  margin: 0 10px;
+  margin: 0 10px 10px;
   background: #333;
   padding: 7px 15px;
   color: #eaeaea;

--- a/events.css
+++ b/events.css
@@ -98,7 +98,6 @@ a:hover {
   padding: 2px 6px;
   height: 23px;
   margin-bottom: 1px;
-  max-width: 184px;
   overflow: hidden;
   text-overflow: ellipsis;
 

--- a/js/table.js
+++ b/js/table.js
@@ -1,11 +1,12 @@
-function generateCalendar (eventData) {
-  monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"]
-  weekdays   = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-  today      = new Date()
-  months = []
-  generateAllTheMonths(eventData)
+var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"]
+var weekdays   = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+var today  = new Date()
+var months = []
 
-  $.each(eventData, function(i, event){
+function generateCalendar (eventData) {
+  var eventData = eventData.sort(function(a, b) { return (new Date(a.startdate)) - (new Date(b.startdate)) })
+  generateAllTheMonths(eventData)
+  eventData.forEach(function (event) {
     appendEvent(event)
   })
 
@@ -17,7 +18,7 @@ function generateCalendar (eventData) {
 function addMonthMenu() {
   $('#calendar-goes-here').prepend('<div id="cal-controls">')
   $('.month-table').each(function(_, table) {
-    month = $(table).data('month')
+    var month = $(table).data('month')
     $('#cal-controls').append('<a class="month-menuitem" data-target="' + month + '" href="#' + month + '">' + month + '</a>')
   })
 
@@ -29,7 +30,7 @@ function addMonthMenu() {
   })
 
   // Get current month and click it
-  currentMonth = $('[data-target=' + monthNames[(new Date()).getMonth()] + ']')
+  var currentMonth = $('[data-target=' + (new Date()).getFullYear() + "-"  + monthNames[(new Date()).getMonth()] + ']')
   if( currentMonth.length ) {
     currentMonth.click()
   } else {
@@ -38,33 +39,33 @@ function addMonthMenu() {
 }
 
 function appendEvent( event ) {
-  eventStartDate = new Date(event.startdate)
-  eventEndDate   = new Date(event.enddate)
-  eventElement   = $('<div class="event"><a target="_blank" href="' + event.website + '" title="' + event.name + '">' + event.name + '</a></div>')
+  var eventStartDate = new Date(event.startdate)
+  var eventEndDate   = new Date(event.enddate)
+  var eventElement   = $('<div class="event"><a target="_blank" href="' + event.website + '">' + event.name + '</a></div>')
 
   // Handle multi-days
-  if( eventEndDate.getDate() ) {
-    date         = eventStartDate
-    spacerNumber = $('#' + formattedDate(eventStartDate)).find('.event').length
+  if ( eventEndDate.getDate() ) {
+    var date         = eventStartDate
+    var spacerNumber = $('#' + formattedDate(eventStartDate)).find('.event').length
     eventElement.addClass('multi-days')
 
-    while( eventEndDate > date ) {
+    while ( eventEndDate > date ) {
       // If reached end of month, go to first day of the next month
       // Else go to the next day
-      if(date == new Date(date.getFullYear(), date.getMonth() + 1, 0)) {
+      if (date == new Date(date.getFullYear(), date.getMonth() + 1, 0)) {
         date == new Date(date.getFullYear(), date.getMonth() + 1, 1)
       } else {
         date = new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1 )
       }
 
       // Add spacer to line up the event
-      dateElement = $('#' + formattedDate(date))
-      steps = dateElement.find('.event').length
+      var dateElement = $('#' + formattedDate(date))
+      var steps = dateElement.find('.event').length
       loopForTimes( spacerNumber - steps, function() {
         dateElement.append('<div class="event spacer">&nbsp;</div>')
       })
 
-      dateElement.removeClass('no-event').append('<div class="event multi-days following-days" title="' + event.name + '"><a target="_blank" href="' + event.website + '">' + event.name + '</a></div>')
+      dateElement.removeClass('no-event').append('<div class="event multi-days following-days" title="' + event.name + '"><a target="_blank" href="' + event.website + '" title="' + event.name + '">' + event.name + '</a></div>')
     }
   }
 
@@ -72,66 +73,67 @@ function appendEvent( event ) {
 }
 
 function generateAllTheMonths( eventData ) {
-  today  = new Date()
-  min    = new Date(today.getFullYear(), today.getMonth() - 5, today.getDate())
-  max    = new Date(today.getFullYear(), today.getMonth() + 6, today.getDate())
-  dates  = eventData.map(function(e) { return [e.startdate, e.enddate] })
-  dates  = [].concat.apply([], dates).filter(function(n) { return n })
-  dates  = dates.map(function (n) { return new Date(n) })
-  dates  = dates.sort(function (a, b) { return a - b })
-  dates  = dates.filter(function (n) { return n > min && n < max })
-  months = []
-  $.each( dates, function(_, date) {
-    if( months.indexOf(date.getMonth()) < 0 ) {
-      months.push(date.getMonth())
+  var dates = []
+  var months = []
+
+  eventData.forEach(function(event) {
+    if (event.startdate) dates.push(event.startdate)
+    if (event.enddate) dates.push(event.enddate)
+  })
+
+  dates.forEach(function (date) {
+    date = new Date(date)
+    if(months.indexOf(date.getFullYear().toString() + date.getMonth()) < 0) {
+      months.push(date.getFullYear().toString() + date.getMonth())
       generateMonthTable(date)
+    } else {
     }
   })
 }
 
 function generateMonthTable( date ) {
-  eventMonthName = monthNames[date.getMonth()]
-  monthTable     = $('<table cellspacing=0 class="month-table" data-month="' + eventMonthName + '" id="month-' + date.getMonth() + '"></table>')
-  monthTableBody = monthTable.append('<tbody>')
-  today          = new Date()
-  endOfToday     = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 00, 00, 00)
-  firstDay       = new Date(date.getFullYear(), date.getMonth(), 1)
-  numberOfDays   = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
-  weekDayNumber  = firstDay.getDay()
+  var eventMonthName = monthNames[date.getMonth()]
+  var monthTable     = $('<table cellspacing=0 class="month-table" data-month="' + date.getFullYear() + "-"  + eventMonthName + '" id="month-' + date.getMonth() + '"></table>')
+  var monthTableBody = monthTable.append('<tbody>')
+  // var today          = new Date()
+  var endOfToday     = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 00, 00, 00)
+  var firstDay       = new Date(date.getFullYear(), date.getMonth(), 1)
+  var numberOfDays   = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
+  var weekDayNumber  = firstDay.getDay()
 
   $('#calendar-goes-here').append(monthTable)
-  monthTable.before('<h2 data-month="' + eventMonthName + '">' + eventMonthName + ' ' + date.getFullYear() + '</h2>')
+  monthTable.before('<h2 data-month="' + date.getFullYear() + '-' + eventMonthName + '">' + eventMonthName + ' ' + date.getFullYear() + '</h2>')
 
   // Add month calendar header
   monthTableBody.append('<tr class="header"></tr>')
-  headerRow = monthTableBody.find('.header')
+  var headerRow = monthTableBody.find('.header')
   loopForTimes( 7, function(i) {
     headerRow.append('<td>' + weekdays[i] + '</td>')
   })
 
   // Add empty days from previous month
-  loopForTimes( weekDayNumber - 1, function() {
+  var times = weekDayNumber == 0 ? 6 : weekDayNumber - 1
+  loopForTimes( times, function() {
     getFirstAvailableRow(monthTable).append('<td class="empty"></td>')
   })
 
   // Filling the month with days
   loopForTimes( numberOfDays, function(daynumber) {
-    thisDay = new Date(date.getFullYear(), date.getMonth(), (daynumber + 1))
-    id = formattedDate(thisDay)
-    pastClass = endOfToday > thisDay ? "past" : ""
+    var thisDay = new Date(date.getFullYear(), date.getMonth(), (daynumber + 1))
+    var id = formattedDate(thisDay)
+    var pastClass = endOfToday > thisDay ? "past" : ""
     getFirstAvailableRow(monthTableBody).append('<td class="no-event ' + pastClass + '" id=' + id + '><div class=day>'+ (daynumber + 1) +'</div></td>')
   })
 
   // Add empty days from next month
-  lastRow = monthTable.find('tr:last')
-  cellsInLastRow = lastRow.find('td').length
+  var lastRow = monthTable.find('tr:last')
+  var cellsInLastRow = lastRow.find('td').length
   // Check if this is necessary
-  if( cellsInLastRow < 7 ) {
+  if ( cellsInLastRow < 7 ) {
     loopForTimes( (7 - cellsInLastRow), function() {
       lastRow.append('<td class="empty"></td>')
     })
   }
-
 }
 
 // Because I don't like ot write for()
@@ -143,18 +145,18 @@ function loopForTimes( times, callback ) {
 
 // This is handy: getting the first row with available cell space
 function getFirstAvailableRow( table ) {
-  row = table.find('tr.days').filter(function(i, thisRow) {
+  var row = table.find('tr.days').filter(function(i, thisRow) {
     return ($(thisRow).find('td').length) < 7
   })
   // If no available row, create a new one
   if( row.length == 0 ) {
     table.append('<tr class=days>')
-    row = table.find('tr').last()
+    var row = table.find('tr').last()
   }
   return row
 }
 
 // Create an unique date string for cell lookup
 function formattedDate( date ) {
-  return monthNames[date.getMonth()] + '-' + date.getDate()
+  return date.getFullYear() + '-' + monthNames[date.getMonth()] + '-' + date.getDate()
 }


### PR DESCRIPTION
This should fix #225.

`table.js` was pretty out of date, this syncs the code with head of https://github.com/jlord/sheetsee-calendar, with [my latest changes](https://github.com/jlord/sheetsee-calendar/compare/5438796350e7d52def89a839f29a12c4963056ee...954d4a86b703244d62b7dbe31ba034a7cb1341e9) that are supposed to address the start date issue.

I've also made some slight CSS changes so it looks less crooked. 

There's an event in 1999, which I assume is incorrect data, maybe someone who has admin access to the spreadsheet can edit it?

**Local env screenshot**

![image](https://cloud.githubusercontent.com/assets/1153134/6185645/e6d887be-b3ab-11e4-97e3-daa2b1434a7d.png)

cc @maxogden @jlord