### PR TITLE
sort events chronologically

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -76,7 +76,7 @@ function sortDates(data) {
   // sort the dates
   var sorted = data
   sorted.sort(function(a,b) {
-    return b.startUTC - a.startUTC
+    return a.startUTC - b.startUTC
   })
 
   return sorted

--- a/js/main.js
+++ b/js/main.js
@@ -64,6 +64,7 @@ function showItemByUrl(frag) {
 
 handleHashChange();
 
+// Sorts chronologically
 function sortDates(data) {
   var today = new Date()
 
@@ -125,6 +126,7 @@ function removeSamePlace(entry) {
 function makeMap(data) {
 
   var sorted = sortDates(data)
+                .reverse()
                 .map(setState)
                 .filter(removeSamePlace())
                 .map(addHexColor.bind(this, "#F7DA03", "#A09C9C"))


### PR DESCRIPTION
Current event list is reverse chronological sorting which is (to me, at least) confusing. I expect the next event to be the first one listed, not the last one listed. This change reverses that sorting for a hopefully more intuitive listing.