### PR TITLE
Improve a11y

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,10 +26,10 @@
         </div>
       </div>
     </header>
-
+    <div id="main" name="main" role="main">
     <div class="container" style="background-color: #fff;">
       <div class="full">
-        <h1 data-i18n="about-h1">About NodeSchool</h1>
+        <h2 data-i18n="about-h1">About NodeSchool</h2>
           <p data-i18n="about-header">NodeSchool is an open source project run by volunteers with two goals: to create high quality programming curriculum and to host community learning events.</p>
       </div>
 
@@ -82,7 +82,7 @@
         </div>
       </div>
     </div>
-
+    </div>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="mapbox.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>nodeschool.io</title>
+    <title>NodeSchool - About</title>
   </head>
   <body class="about">
     <header>
@@ -29,13 +29,13 @@
     <div id="main" name="main" role="main">
     <div class="container" style="background-color: #fff;">
       <div class="full">
-        <h2 data-i18n="about-h1">About NodeSchool</h2>
+        <h1 data-i18n="about-h1">About NodeSchool</h1>
           <p data-i18n="about-header">NodeSchool is an open source project run by volunteers with two goals: to create high quality programming curriculum and to host community learning events.</p>
       </div>
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="about-header-history-title">Interactive tutorials</h3>
+          <h2 data-i18n="about-header-history-title">Interactive tutorials</h2>
         </div>
         <div class="two-thirds">
 <p data-i18n="about-history">The &quot;workshopper&quot; format was first created by <a href="http://substack.net/">Substack of the Internet</a> in Summer 2013 when he wrote the <a href="https://www.npmjs.org/package/stream-adventure">stream-adventure</a> workshopper.</p>

--- a/building-workshops.html
+++ b/building-workshops.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>nodeschool.io</title>
+    <title>NodeSchool - Building a Workshop</title>
   </head>
   <body class="building-workshops">
     <header>
@@ -34,7 +34,7 @@
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="building-workshops-title-info"><a href="https://www.npmjs.org/package/workshopper">workshopper</a></h3>
+          <h2 data-i18n="building-workshops-title-info"><a href="https://www.npmjs.org/package/workshopper">workshopper</a></h2>
         </div>
         <div class="two-thirds">
           <p><a href="https://www.npmjs.org/package/workshopper"><code>npm install workshopper</code></a> <span data-i18n="building-workshops-info">to get a full featured nodeschool CLI workshop framework.</span></p>
@@ -43,7 +43,7 @@
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="building-workshops-title-info2"><a href="https://www.npmjs.org/package/adventure">adventure</a></h3>
+          <h2 data-i18n="building-workshops-title-info2"><a href="https://www.npmjs.org/package/adventure">adventure</a></h2>
         </div>
         <div class="two-thirds">
           <p><a href="https://www.npmjs.org/package/adventure"><code>npm install adventure</code></a> <span data-i18n="building-workshops-info2">to get an alternative to workshopper that is lighter weight.</span></p>
@@ -52,7 +52,7 @@
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="building-workshops-title-info3">Build your own</h3>
+          <h2 data-i18n="building-workshops-title-info3">Build your own</h2>
         </div>
         <div class="two-thirds">
           <p data-i18n="building-workshops-info3"><span>Don&apos;t be afraid to hack the format! E.g. if you want to write a workshop to teach CSS you may have to invent your own workshop format. For example the</span> <a href="https://www.npmjs.org/package/browser-menu">browser-menu</a> <span>module was written for the</span> <a href="https://www.npmjs.org/package/shader-school">shader-school</a> <span>workshop.</span></p>

--- a/building-workshops.html
+++ b/building-workshops.html
@@ -25,7 +25,7 @@
           </div>
         </div>
     </header>
-
+    <div id="main" name="main" role="main">
     <div class="container" style="background-color: #fff;">
       <div class="full">
         <h1 data-i18n="building-workshops-header">Building a NodeSchool Workshop</h1>
@@ -59,7 +59,7 @@
         </div>
       </div>
     </div>
-
+    </div>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/chapters.html
+++ b/chapters.html
@@ -27,7 +27,7 @@
         </div>
       </div>
     </header>
-
+    <div id="main" name="main" role="main">
     <div class="container" style="background-color: #fff;">
       <div class="full">
         <h1 data-i18n="chapters-h1">NodeSchool Chapters</h1>
@@ -45,7 +45,7 @@
           </div>
         </div>
       </div>
-
+    </div>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/chapters.html
+++ b/chapters.html
@@ -9,7 +9,7 @@
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="mapbox.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>nodeschool.io</title>
+    <title>NodeSchool - Chapters</title>
   </head>
   <body class="chapters">
     <header>

--- a/events.html
+++ b/events.html
@@ -27,7 +27,7 @@
         </div>
       </div>
     </header>
-
+    <div id="main" name="main" role="main">
     <div class="container workshops" style="background-color: #fff;">
       <div class="full">
         <h1 data-i18n="events-header">Past and Future NodeSchool Events</h1><br><br>
@@ -54,7 +54,7 @@
         </div>
       </div>
     </div>
-
+  </div>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/events.html
+++ b/events.html
@@ -9,7 +9,7 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>nodeschool.io</title>
+    <title>NodeSchool - Past and Future Events</title>
   </head>
   <body class="events">
     <header>
@@ -31,7 +31,7 @@
     <div class="container workshops" style="background-color: #fff;">
       <div class="full">
         <h1 data-i18n="events-header">Past and Future NodeSchool Events</h1><br><br>
-        <div id="map"></div>
+        <div aria-hidden="true" id="map"></div>
         <div class="key">
           <span class="key-past" data-i18n="events-past">Past</span>
           <span class="key-future" data-i18n="events-future">Future</span>
@@ -39,8 +39,8 @@
       </div>
       <br><br>
       <div class="full">
-        <h2 data-i18n="events-header2">There have been <strong><span id="event-count">many</span></strong> events!</h2>
-        <h3 data-i18n="events-header3">If you&apos;re organizing a NodeSchool event, add it to this site by filling out <a href="https://docs.google.com/forms/d/1vYW-Yw82kt_q7WDgBY6gQqFrg3zuD2rDPXEG-cbq7e4/viewform?usp=form_confirm" target="_blank">this form</a>.</h3>
+        <p data-i18n="events-header2">There have been <strong><span id="event-count">many</span></strong> events!</p>
+        <p data-i18n="events-header3">If you&apos;re organizing a NodeSchool event, add it to this site by filling out <a href="https://docs.google.com/forms/d/1vYW-Yw82kt_q7WDgBY6gQqFrg3zuD2rDPXEG-cbq7e4/viewform?usp=form_confirm" target="_blank">this form</a>.</p>
         <small data-i18n="events-small">If you need to edit an event you&apos;ve submitted, <a href="https://github.com/nodeschool/organizers/issues/new">file an issue on nodeschool/organizers.</a></small>
       </div>
     </div>
@@ -48,7 +48,7 @@
     <div id="calendar">
       <div class="container" style="background-color: #fff;">
         <div class="full">
-          <h1 data-i18n="calendar-h1">Calendar</h1>
+          <h2 class="big-heading" data-i18n="calendar-h1">Calendar</h2>
           <br><br>
           <div id="calendar-goes-here"></div>
         </div>

--- a/hexdex.html
+++ b/hexdex.html
@@ -37,55 +37,55 @@
       </div>
       <div class="two-thirds">
           <a class="imglink" href="https://github.com/nodeschool/hamburg" title="Hamburg">
-            <img class="hex" src="images/nodeschool-ham.svg">
+            <img class="hex" src="images/nodeschool-ham.svg" alt="Hamburg Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/london" title="London">
-            <img class="hex" src="images/nodeschool-london-official.png">
+            <img class="hex" src="images/nodeschool-london-official.png" alt="London Hexagon (old)">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/london" title="London">
-            <img class="hex" src="images/battersea-power-node.svg">
+            <img class="hex" src="images/battersea-power-node.svg"  alt="London Hexagon (new)">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/oakland" title="Oakland">
-            <img class="hex" src="images/oaklandnodeschool.png">
+            <img class="hex" src="images/oaklandnodeschool.png"  alt="Oakland Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/buenosaires" title="Buenos Aires">
-            <img class="hex" src="images/nodeschool-buenos-aires.png">
+            <img class="hex" src="images/nodeschool-buenos-aires.png"  alt="Buenos Aires Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/stavanger" title="Stavanger">
-            <img class="hex" src="images/nodeschool-stavanger.png">
+            <img class="hex" src="images/nodeschool-stavanger.png" alt="Stavanger hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/osaka" title="Osaka">
-            <img class="hex" src="images/nodeschool-osaka.png">
+            <img class="hex" src="images/nodeschool-osaka.png" alt="Osaka Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/hradec-kralove" title="Hradec Králové">
-            <img class="hex" src="images/nodeschool-hradec-kralove.svg">
+            <img class="hex" src="images/nodeschool-hradec-kralove.svg" alt="Hradec Králové Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/silesia" title="Silesia">
-            <img class="hex" src="images/nodeschool-silesia.svg">
+            <img class="hex" src="images/nodeschool-silesia.svg" alt="Silesia Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/bali" title="Bali">
-            <img class="hex" src="images/nodeschool-bali-sticker.png">
+            <img class="hex" src="images/nodeschool-bali-sticker.png" alt="Bali Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/portland-me" title="Portland, ME">
-            <img class="hex" src="images/nodeschool_pwm_logo.png">
+            <img class="hex" src="images/nodeschool_pwm_logo.png" alt="Portland Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/dallas" title="Dallas, TX">
-            <img class="hex" src="images/nodeschool-dallas.svg">
+            <img class="hex" src="images/nodeschool-dallas.svg" alt="Dallas, Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/mexicocity" title="Mexico City">
-            <img class="hex" src="images/nodeschool-mexicocity.svg">
+            <img class="hex" src="images/nodeschool-mexicocity.svg" alt="Mexico, Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/xian" title="Xi'an, Shaanxi">
-            <img class="hex" src="images/nodeschool-xian.svg">
+            <img class="hex" src="images/nodeschool-xian.svg" alt="Xi'an, Shaanxi Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/medellin" title="Medellín">
-            <img class="hex" src="images/nodeschool-medellin.png">
+            <img class="hex" src="images/nodeschool-medellin.png" alt="Medellín Hexagon">
           </a>
           <a class="imglink" href="https://github.com/nodeschool/kyiv" title="Kyiv">
             <img src="images/nodeschool-kyiv.png" alt="Kyiv hex with dollhouse" class="hex">
           </a>
-          <img class="hex" src="images/nodeschool-blank.png">
-          <img class="hex" src="images/nodeschool-blank.png">
+          <img class="hex" src="images/nodeschool-blank.png" alt="blank hexagon" aria-hidden="true">
+          <img class="hex" src="images/nodeschool-blank.png" alt="blank hexagon" aria-hidden="true">
       </div>
     </div>
 

--- a/hexdex.html
+++ b/hexdex.html
@@ -27,7 +27,7 @@
         </div>
       </div>
     </header>
-
+    <div id="main" role="main">
     <div class="container" style="background-color: #fff;">
       <div class="third">
         <h1 data-i18n="hexdex-h1">Hexdex</h1>
@@ -88,7 +88,7 @@
           <img class="hex" src="images/nodeschool-blank.png" alt="blank hexagon" aria-hidden="true">
       </div>
     </div>
-
+  </div>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/host.html
+++ b/host.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>nodeschool.io</title>
+    <title>NodeSchool - Hosting a NodeSchool event</title>
   </head>
   <body class="host">
     <div class="first-photo"></div>
@@ -35,7 +35,7 @@
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="host-attend-header">First, create a chapter</h3>
+          <h2 data-i18n="host-attend-header">First, create a chapter</h2>
         </div>
         <div class="two-thirds">
           <p><strong><span data-i18n="host-chapter-info">First you should</span> <a href="https://github.com/nodeschool/organizers/blob/master/README.md#how-to-start-a-new-nodeschool-chapter" data-i18n="host-chapter-link">get a new NodeSchool Chapter set up</a><span data-i18n="host-chapter-info2">. Once that is done see below for resources about hosting your first event.</span></strong></p>
@@ -45,7 +45,7 @@
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="host-event-header">Add Your Event!</h3>
+          <h2 data-i18n="host-event-header">Add Your Event!</h2>
         </div>
         <div class="two-thirds">
           <p data-i18n="host-event-info"><span>If you&apos;re organizing a NodeSchool event, add it to this site by filling out</span> <a href="https://docs.google.com/forms/d/1vYW-Yw82kt_q7WDgBY6gQqFrg3zuD2rDPXEG-cbq7e4/viewform?usp=form_confirm" target="_blank">this form</a><span>.</span></p>
@@ -54,7 +54,7 @@
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="host-recommendation-header">Hosting Suggestions</h3>
+          <h2 data-i18n="host-recommendation-header">Hosting Suggestions</h2>
         </div>
         <div class="two-thirds">
           <p data-i18n="host-recommendation-info">As you can see from the above writeups there is a lot of flexiblity in the specifics of running an event, but we have found some of the following suggestions to be universally helpful:</p>
@@ -71,7 +71,7 @@
 
       <div class="container" id="writeups">
         <div class="third">
-          <h3 data-i18n="host-reports-header">Previous Event Writeups</h3>
+          <h2 data-i18n="host-reports-header">Previous Event Writeups</h2>
         </div>
         <div class="two-thirds">
           <p data-i18n="host-reports-info">Here are some in-depth post-mortems of previous NodeSchool events to give you an idea of the format and how things go</p>

--- a/host.html
+++ b/host.html
@@ -26,7 +26,7 @@
         </div>
       </div>
     </header>
-
+    <div id="main" name="main" role="main">
     <div class="container" style="background-color: #fff;">
       <div class="full">
         <h1 data-i18n="host-header">Hosting a NodeSchool Event</h1>
@@ -92,7 +92,7 @@
       </div>
 
     </div>
-
+  </div>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/index.html
+++ b/index.html
@@ -14,15 +14,8 @@
     <header>
       <div class="container">
         <div class="full">
-          <img src="images/schoolhouse.svg" alt="">
-          <h1 class="name">
-            <span>NODE</span>
-            <span class="apostrophe"></span>
-            <span>S</span>
-            <span class="c">C</span>
-            <span class="h">H</span>
-            <span>OOL</span>
-          </h1>
+          <img src="images/schoolhouse.svg" alt="nodeschool logo">
+          <h1 class="name">nodeschool</h1>
           <h3 class="subtitle" data-i18n="index-header-top">Open source workshops that teach web software skills. Do them on your own or at a workshop nearby.</h3>
           <nav role="navigation">
             <ul class="nav">

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="container workshops" style="background-color: #fff;">
-      <div class="third">
+      <div class="third" aria-hidden="true">
         <div id="map"></div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro" rel="stylesheet" type="text/css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>nodeschool.io</title>
+    <title>NodeSchool</title>
   </head>
   <body>
     <header>
@@ -32,15 +32,18 @@
       </div>
     </header>
     <div id="main" name="main" role="main">
+    <section>
     <div class="container workshop-header" style="background-color: #fff;">
       <div class="full">
-        <h2 data-i18n="index-workshop-header">Workshops</h2>
+        <h2 class="big-heading" data-i18n="index-workshop-header">Workshops</h2>
         <p data-i18n="index-workshop-info">These are in-person hosted workshops, usually free, in which workshoppers are used as curriculum and mentors help attendees work through the challenges.</p>
-        <ul class="inner-nav">
-          <li><a href="host.html" data-i18n="index-workshop-links-host">Host Your Own</a></li>
-          <li><a href="events.html" data-i18n="index-workshop-links-events">See All Events</a></li>
-          <li><a href="host.html#writeups" data-i18n="index-workshop-links-writeups">Writeups of Past Events</a></li>
-        </ul>
+        <nav>
+          <ul class="inner-nav">
+            <li><a href="host.html" data-i18n="index-workshop-links-host">Host Your Own</a></li>
+            <li><a href="events.html" data-i18n="index-workshop-links-events">See All Events</a></li>
+            <li><a href="host.html#writeups" data-i18n="index-workshop-links-writeups">Writeups of Past Events</a></li>
+          </ul>
+        </nav>
       </div>
     </div>
     <div class="container workshops" style="background-color: #fff;">
@@ -49,7 +52,7 @@
       </div>
 
       <div class="third upcoming-workshoppers">
-        <h3 data-i18n="index-upcoming-header">Upcoming Workshops</h3>
+        <h4 data-i18n="index-upcoming-header">Upcoming Workshops</h4>
         <div id="upcoming-workshops">
           <div class="loading" data-i18n="index-upcoming-loading">
             Loading...
@@ -68,23 +71,27 @@
       </div>
 
       <div class="third anyone-can-host">
-        <h3 data-i18n="index-host-header">Anyone can host</h3>
+        <h4 data-i18n="index-host-header">Anyone can host</h4>
         <p id="event-count"><span data-i18n="index-host-past">There have been a total of</span> <strong class="cnt">?</strong> <span data-i18n="index-host-past2">events!</span></p>
         <p><span data-i18n="index-host-want-to-host">NodeSchool is decentralized, open source and volunteer run. Want to host an event?</span> <a href="host.html" data-i18n="index-host-want-to-host2">Resources and tips</a> <span data-i18n="index-host-want-to-host3">for how.</span></p>
       </div>
     </div>
+  </section>
 
+    <section>
     <div id="workshoppers">
       <div class="container">
         <div class="full">
-          <h2 data-i18n="index-workshopper-header">Workshoppers</h2>
+          <h2 class="big-heading" data-i18n="index-workshopper-header">Workshoppers</h2>
           <p data-i18n="index-workshopper-info">Workshopper is the name used for the open source lesson modules associated with NodeSchool. All are self guided (you don&apos;t need to attend a workshop to do one) and most work offline.</p>
-          <ul class="inner-nav">
-            <li><a href="#workshopper-list" data-i18n="index-workshopper-list-view">View Workshopper List</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" data-i18n="index-workshopper-list-problem">Ask Questions if Stuck</a></li>
-            <li><a href="https://github.com/nodeschool/discussions" data-i18n="index-workshopper-list-faq">Answer Questions</a></li>
-            <li><a href="building-workshops.html" data-i18n="index-workshopper-list-host">Build a Workshop</a></li>
-          </ul>
+          <nav>
+            <ul class="inner-nav">
+              <li><a href="#workshopper-list" data-i18n="index-workshopper-list-view">View Workshopper List</a></li>
+              <li><a href="https://github.com/nodeschool/discussions/issues/new" data-i18n="index-workshopper-list-problem">Ask Questions if Stuck</a></li>
+              <li><a href="https://github.com/nodeschool/discussions" data-i18n="index-workshopper-list-faq">Answer Questions</a></li>
+              <li><a href="building-workshops.html" data-i18n="index-workshopper-list-host">Build a Workshop</a></li>
+            </ul>
+          </nav>
         </div>
       </div>
       <div class="container">
@@ -130,41 +137,41 @@
           </div>
         </div>
       </div>
-    </div>
+    </section>
 
     <div class="window-pane"><span class="caption">NodeConf, 2014</span></div>
 
       <div id="workshopper-list" class="container core-workshoppers" style="background-color: #fff;">
         <div class="third">
-          <h2 data-i18n="index-workshoppers-core-header">Core</h2>
+          <h3 data-i18n="index-workshoppers-core-header">Core</h3>
           <p data-i18n="index-workshoppers-core-info">These workshoppers focus on essential skills for working with Node.js.</p>
           <p><span data-i18n="index-workshoppers-core-link-pre">Stuck? Ask a question in the</span> <a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" data-i18n="index-workshoppers-core-link-text">discussion</a><span data-i18n="index-workshoppers-core-link-post">.</span></p>
         </div>
         <div class="third">
           <div id="javascripting" class="workshopper">
-            <h3><a href="https://www.github.com/sethvincent/javascripting" target="_blank">javascripting</a></h3>
+            <h4><a href="https://www.github.com/sethvincent/javascripting" target="_blank">javascripting</a></h4>
             <p data-i18n="workshopper-javascripting">Learn the basics of JavaScript. No previous programming experience required.</p>
             <code>npm install -g javascripting</code>
           </div>
           <div id="gitit" class="workshopper">
-            <h3><a href="https://www.github.com/jlord/git-it" target="_blank">git-it</a></h3>
+            <h4><a href="https://www.github.com/jlord/git-it" target="_blank">git-it</a></h4>
             <p data-i18n="workshopper-gitit">Learn Git and GitHub basics.</p>
             <code>npm install -g git-it</code>
           </div>
         </div>
         <div class="third">
           <div id="learnyounode" class="workshopper">
-            <h3><a href="https://www.github.com/rvagg/learnyounode" target="_blank">learnyounode</a></h3>
+            <h4><a href="https://www.github.com/rvagg/learnyounode" target="_blank">learnyounode</a></h4>
             <p data-i18n="workshopper-learnyounode">Learn the basics of node: asynchronous i/o, http.</p>
             <code data-i18n="workshopper-learnyounode-command">npm install -g learnyounode</code>
           </div>
           <div id="how-to-npm" class="workshopper">
-            <h3><a href="https://github.com/npm/how-to-npm" target="_blank">How to npm</a></h3>
+            <h4><a href="https://github.com/npm/how-to-npm" target="_blank">How to npm</a></h4>
             <p data-i18n="workshopper-how-to-npm">Learn how to use and create npm modules.</p>
             <code>npm install -g how-to-npm</code>
           </div>
           <div id="streamadventure" class="workshopper">
-            <h3><a href="https://www.github.com/substack/stream-adventure" target="_blank">stream-adventure</a></h3>
+            <h4><a href="https://www.github.com/substack/stream-adventure" target="_blank">stream-adventure</a></h4>
             <p><span data-i18n="workshopper-streamadventure">Learn to compose streaming interfaces with </span><code>.pipe()</code><span data-i18n="workshopper-streamadventure2">.</span></p>
             <code>npm install -g stream-adventure</code>
           </div>
@@ -173,63 +180,63 @@
 
     <div class="container elective-workshoppers" style="background-color: #fff;">
       <div class="third">
-        <h2 data-i18n="index-workshoppers-elective-header">Electives</h2>
+        <h3 data-i18n="index-workshoppers-elective-header">Electives</h3>
         <p data-i18n="index-workshoppers-elective-info">Workshoppers on popular libraries or styles of writing Node.js.</p>
         <p><span data-i18n="index-workshoppers-elective-link-pre">Stuck? Ask a question in the </span> <a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" data-i18n="index-workshoppers-elective-link-text">discussion</a><span data-i18n="index-workshoppers-elective-link-post">.</span></p>
       </div>
       <div class="third">
         <div id="functionaljavascript" class="workshopper">
-          <h3><a href="https://github.com/timoxley/functional-javascript-workshop" target="_blank">Functional Javascript</a></h3>
+          <h4><a href="https://github.com/timoxley/functional-javascript-workshop" target="_blank">Functional Javascript</a></h4>
           <p data-i18n="workshopper-functionaljavascript">Learn fundamental functional programming features of JavaScript in vanilla ES5.</p>
           <code>npm install -g functional-javascript-workshop</code>
         </div>
         <div id="levelmeup" class="workshopper">
-          <h3><a href="https://github.com/rvagg/levelmeup" target="_blank">Level Me Up Scotty!</a></h3>
+          <h4><a href="https://github.com/rvagg/levelmeup" target="_blank">Level Me Up Scotty!</a></h4>
           <p data-i18n="workshopper-levelmeup">Learn to use leveldb, a simple key/value store with a vibrant package.</p>
           <code>npm install -g levelmeup</code>
         </div>
         <div id="expressworks" class="workshopper">
-          <h3><a href="https://github.com/azat-co/expressworks" target="_blank">ExpressWorks</a></h3>
+          <h4><a href="https://github.com/azat-co/expressworks" target="_blank">ExpressWorks</a></h4>
           <p data-i18n="workshopper-expressworks">Learn the basics of the Express.js framework.</p>
           <code>npm install -g expressworks</code>
         </div>
         <div id="makemehapi" class="workshopper">
-          <h3><a href="https://github.com/spumko/makemehapi" target="_blank">Make Me Hapi</a></h3>
+          <h4><a href="https://github.com/spumko/makemehapi" target="_blank">Make Me Hapi</a></h4>
           <p data-i18n="workshopper-makemehapi">Learn all about hapi through a series of challenges.</p>
           <code>npm install -g makemehapi</code>
         </div>
         <div id="promise-it-wont-hurt" class="workshopper">
-          <h3><a href="https://github.com/stevekane/promise-it-wont-hurt" target="_blank">Promise It Won&apos;t Hurt</a></h3>
+          <h4><a href="https://github.com/stevekane/promise-it-wont-hurt" target="_blank">Promise It Won&apos;t Hurt</a></h4>
           <p data-i18n="workshopper-promise-it-wont-hurt">Learn to use promises in JavaScript to handle async operations.</p>
           <code>npm install -g promise-it-wont-hurt</code>
         </div>
         <div id="async-you" class="workshopper">
-          <h3><a href="https://github.com/bulkan/async-you" target="_blank">Async You</a></h3>
+          <h4><a href="https://github.com/bulkan/async-you" target="_blank">Async You</a></h4>
           <p data-i18n="workshopper-async-you">Learn to use the async package.</p>
           <code>npm install -g async-you</code>
         </div>
         <div id="nodebot-workshop" class="workshopper">
-          <h3><a href="https://github.com/tableflip/nodebot-workshop" target="_blank">NodeBot Workshop</a></h3>
+          <h4><a href="https://github.com/tableflip/nodebot-workshop" target="_blank">NodeBot Workshop</a></h4>
           <p data-i18n="workshopper-nodebot-workshop">Make robots with the johnny-five api.</p>
           <code>npm install -g nodebot-workshop</code>
         </div>
         <div id="goingnative" class="workshopper">
-          <h3><a href="https://github.com/rvagg/goingnative" target="_blank">Going Native</a></h3>
+          <h4><a href="https://github.com/rvagg/goingnative" target="_blank">Going Native</a></h4>
           <p data-i18n="workshopper-goingnative">An exploration of Node.js from the underside: native C++ add-ons.</p>
           <code>npm install -g goingnative</code>
         </div>
         <div id="planetproto" class="workshopper">
-          <h3><a href="https://github.com/sporto/planetproto" target="_blank">Planet Proto</a></h3>
+          <h4><a href="https://github.com/sporto/planetproto" target="_blank">Planet Proto</a></h4>
           <p data-i18n="workshopper-planetproto">Understanding JavaScript Prototypes</p>
           <code>npm install -g planetproto</code>
         </div>
         <div id="webgl-workshop" class="workshopper">
-          <h3><a href="https://github.com/stackgl/webgl-workshop" target="_blank">WebGL Workshop</a></h3>
+          <h4><a href="https://github.com/stackgl/webgl-workshop" target="_blank">WebGL Workshop</a></h4>
           <p data-i18n="workshopper-webgl-workshop">Learn the basics of WebGL in small, manageable chunks.</p>
           <code>npm install -g webgl-workshop</code>
         </div>
         <div id="test-anything" class="workshopper">
-          <h3><a href="https://github.com/finnp/test-anything" target="_blank">Test Anything</a></h3>
+          <h4><a href="https://github.com/finnp/test-anything" target="_blank">Test Anything</a></h4>
           <p data-i18n="workshopper-test-anything">Learn to test your code</p>
           <code>npm install -g test-anything</code>
         </div>
@@ -238,57 +245,57 @@
 
       <div class="third">
         <div id="shader-school" class="workshopper">
-          <h3><a href="https://github.com/gl-modules/shader-school" target="_blank">Shader School</a></h3>
+          <h4><a href="https://github.com/gl-modules/shader-school" target="_blank">Shader School</a></h4>
           <p data-i18n="workshopper-shader-school">Learn the fundamentals of graphics programming using GLSL shaders.</p>
           <code>npm install -g shader-school</code>
         </div>
         <div id="bytewiser" class="workshopper">
-          <h3><a href="https://www.github.com/maxogden/bytewiser" target="_blank">Bytewiser</a></h3>
+          <h4><a href="https://www.github.com/maxogden/bytewiser" target="_blank">Bytewiser</a></h4>
           <p data-i18n="workshopper-bytewiser">Learn how to manipulate binary data in node.js and HTML5 browsers.</p>
           <code>npm install -g bytewiser</code>
         </div>
         <div id="bug-clinic" class="workshopper">
-          <h3><a href="https://github.com/othiym23/bug-clinic" target="_blank">Bug Clinic</a></h3>
+          <h4><a href="https://github.com/othiym23/bug-clinic" target="_blank">Bug Clinic</a></h4>
           <p data-i18n="workshopper-bug-clinic">Learn some new tools and techniques as you improve your debugging skills.</p>
           <code>npm install -g bug-clinic</code>
         </div>
         <div id="browserify-adventure" class="workshopper">
-          <h3><a href="https://github.com/substack/browserify-adventure" target="_blank">Browserify Adventure</a></h3>
+          <h4><a href="https://github.com/substack/browserify-adventure" target="_blank">Browserify Adventure</a></h4>
           <p data-i18n="workshopper-browserify-adventure">Use npm modules and node-style require() in the browser with browserify.</p>
           <code>npm install -g browserify-adventure</code>
         </div>
         <div id="introtowebgl" class="workshopper">
-          <h3><a href="https://github.com/alexmackey/IntroToWebGLWithThreeJS" target="_blank">Intro to WebGL</a></h3>
+          <h4><a href="https://github.com/alexmackey/IntroToWebGLWithThreeJS" target="_blank">Intro to WebGL</a></h4>
           <p data-i18n="workshopper-introtowebgl">Get started with three.js and WebGL.</p>
           <code>npm install -g introtowebgl</code>
         </div>
         <div id="count-to-6" class="workshopper">
-          <h3><a href="https://github.com/domenic/count-to-6" target="_blank">Count to 6</a></h3>
+          <h4><a href="https://github.com/domenic/count-to-6" target="_blank">Count to 6</a></h4>
           <p data-i18n="workshopper-count-to-6">Learn how to use some features from ES6, the next version of JavaScript.</p>
           <code>npm install -g count-to-6</code>
         </div>
         <div id="kick-off-koa" class="workshopper">
-          <h3><a href="https://github.com/koajs/kick-off-koa" target="_blank">Kick off Koa</a></h3>
+          <h4><a href="https://github.com/koajs/kick-off-koa" target="_blank">Kick off Koa</a></h4>
           <p data-i18n="workshopper-kick-off-koa">Getting started with Koa, the next generation web framework for Node.js.</p>
           <code>npm install -g kick-off-koa</code>
         </div>
         <div id="lololodash" class="workshopper">
-          <h3><a href="https://github.com/mdunisch/lololodash" target="_blank">LololoDash</a></h3>
+          <h4><a href="https://github.com/mdunisch/lololodash" target="_blank">LololoDash</a></h4>
           <p data-i18n="workshopper-lololodash">Learn Lo-Dash (fork of underscore) to handle your arrays and objects simple!</p>
           <code>npm install -g lololodash</code>
         </div>
         <div id="learnyoucouchdb" class="workshopper">
-          <h3><a href="https://github.com/robertkowalski/learnyoucouchdb" target="_blank">learnyoucouchdb</a></h3>
+          <h4><a href="https://github.com/robertkowalski/learnyoucouchdb" target="_blank">learnyoucouchdb</a></h4>
           <p data-i18n="workshopper-learnyoucouchdb">Learn about CouchDB - the database that completely embraces the web</p>
           <code>npm install -g learnyoucouchdb</code>
         </div>
         <div id="learnuv" class="workshopper">
-          <h3><a href="https://github.com/thlorenz/learnuv" target="_blank">learnuv</a></h3>
+          <h4><a href="https://github.com/thlorenz/learnuv" target="_blank">learnuv</a></h4>
           <p data-i18n="workshopper-learnuv">Learn uv for fun and profit, a self guided workshop to the library that powers Node.js.</p>
           <code>git clone https://github.com/thlorenz/learnuv.git &amp;&amp; cd learnuv &amp;&amp; npm install</code>
         </div>
         <div id="learn-generators" class="workshopper">
-          <h3><a href="https://github.com/isRuslan/learn-generators" target="_blank">Learn Generators</a></h3>
+          <h4><a href="https://github.com/isRuslan/learn-generators" target="_blank">Learn Generators</a></h4>
           <p data-i18n="workshopper-learn-generators">An Intro to JavaScript ES6 Generators.</p>
           <code>npm install -g learn-generators</code>
         </div>
@@ -296,6 +303,7 @@
         </div>
       </div>
     </div>
+    </section>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <div class="full">
           <img src="images/schoolhouse.svg" alt="nodeschool logo">
           <h1 class="name">nodeschool</h1>
-          <h3 class="subtitle" data-i18n="index-header-top">Open source workshops that teach web software skills. Do them on your own or at a workshop nearby.</h3>
+          <p class="subtitle" data-i18n="index-header-top">Open source workshops that teach web software skills. Do them on your own or at a workshop nearby.</p>
           <nav role="navigation">
             <ul class="nav">
               <li><a href="#workshoppers" data-i18n="menu-tutorials">Tutorials</a></li>
@@ -27,14 +27,14 @@
               <li><a href="host.html" data-i18n="menu-host">Host</a></li>
             </ul>
           </nav>
-          <h3 data-i18n="index-header-bottom">Get started by installing one of our <a class="big-link" href="#workshopper-list">core workshops</a> or subscribe to our free <a class="big-link" href="https://tinyletter.com/nodeschool" target="_blank">email newsletter</a>.</h3>
+          <p data-i18n="index-header-bottom">Get started by installing one of our <a class="big-link" href="#workshopper-list">core workshops</a> or subscribe to our free <a class="big-link" href="https://tinyletter.com/nodeschool" target="_blank">email newsletter</a>.</p>
         </div>
       </div>
     </header>
 
     <div class="container workshop-header" style="background-color: #fff;">
       <div class="full">
-        <h1 data-i18n="index-workshop-header">Workshops</h1>
+        <h2 data-i18n="index-workshop-header">Workshops</h2>
         <p data-i18n="index-workshop-info">These are in-person hosted workshops, usually free, in which workshoppers are used as curriculum and mentors help attendees work through the challenges.</p>
         <ul class="inner-nav">
           <li><a href="host.html" data-i18n="index-workshop-links-host">Host Your Own</a></li>
@@ -49,7 +49,7 @@
       </div>
 
       <div class="third upcoming-workshoppers">
-        <h2 data-i18n="index-upcoming-header">Upcoming Workshops</h2>
+        <h3 data-i18n="index-upcoming-header">Upcoming Workshops</h3>
         <div id="upcoming-workshops">
           <div class="loading" data-i18n="index-upcoming-loading">
             Loading...
@@ -68,7 +68,7 @@
       </div>
 
       <div class="third anyone-can-host">
-        <h2 data-i18n="index-host-header">Anyone can host</h2>
+        <h3 data-i18n="index-host-header">Anyone can host</h3>
         <p id="event-count"><span data-i18n="index-host-past">There have been a total of</span> <strong class="cnt">?</strong> <span data-i18n="index-host-past2">events!</span></p>
         <p><span data-i18n="index-host-want-to-host">NodeSchool is decentralized, open source and volunteer run. Want to host an event?</span> <a href="host.html" data-i18n="index-host-want-to-host2">Resources and tips</a> <span data-i18n="index-host-want-to-host3">for how.</span></p>
       </div>
@@ -77,7 +77,7 @@
     <div id="workshoppers">
       <div class="container">
         <div class="full">
-          <h1 data-i18n="index-workshopper-header">Workshoppers</h1>
+          <h2 data-i18n="index-workshopper-header">Workshoppers</h2>
           <p data-i18n="index-workshopper-info">Workshopper is the name used for the open source lesson modules associated with NodeSchool. All are self guided (you don&apos;t need to attend a workshop to do one) and most work offline.</p>
           <ul class="inner-nav">
             <li><a href="#workshopper-list" data-i18n="index-workshopper-list-view">View Workshopper List</a></li>
@@ -121,7 +121,7 @@
 
         <div class="third">
           <div id="get-going">
-            <h2 data-i18n="index-get-going-header">Get Going &#x2014;</h2>
+            <h3 data-i18n="index-get-going-header">Get Going &#x2014;</h3>
             <p><span data-i18n="index-get-going-info">You&#x2019;ll need</span> <a href="http://nodejs.org">Node.js</a> <span data-i18n="index-get-going-info2">on your computer to get started
     with each of these. Then use</span> <a href="http://npmjs.org">npm</a> <span data-i18n="index-get-going-info3">(it comes with Node) to install each
     module with the command below it. Once installed,
@@ -136,35 +136,35 @@
 
       <div id="workshopper-list" class="container core-workshoppers" style="background-color: #fff;">
         <div class="third">
-          <h1 data-i18n="index-workshoppers-core-header">Core</h1>
+          <h2 data-i18n="index-workshoppers-core-header">Core</h2>
           <p data-i18n="index-workshoppers-core-info">These workshoppers focus on essential skills for working with Node.js.</p>
           <p><span data-i18n="index-workshoppers-core-link-pre">Stuck? Ask a question in the</span> <a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" data-i18n="index-workshoppers-core-link-text">discussion</a><span data-i18n="index-workshoppers-core-link-post">.</span></p>
         </div>
         <div class="third">
           <div id="javascripting" class="workshopper">
-            <h2><a href="https://www.github.com/sethvincent/javascripting" target="_blank">javascripting</a></h2>
+            <h3><a href="https://www.github.com/sethvincent/javascripting" target="_blank">javascripting</a></h3>
             <p data-i18n="workshopper-javascripting">Learn the basics of JavaScript. No previous programming experience required.</p>
             <code>npm install -g javascripting</code>
           </div>
           <div id="gitit" class="workshopper">
-            <h2><a href="https://www.github.com/jlord/git-it" target="_blank">git-it</a></h2>
+            <h3><a href="https://www.github.com/jlord/git-it" target="_blank">git-it</a></h3>
             <p data-i18n="workshopper-gitit">Learn Git and GitHub basics.</p>
             <code>npm install -g git-it</code>
           </div>
         </div>
         <div class="third">
           <div id="learnyounode" class="workshopper">
-            <h2><a href="https://www.github.com/rvagg/learnyounode" target="_blank">learnyounode</a></h2>
+            <h3><a href="https://www.github.com/rvagg/learnyounode" target="_blank">learnyounode</a></h3>
             <p data-i18n="workshopper-learnyounode">Learn the basics of node: asynchronous i/o, http.</p>
             <code data-i18n="workshopper-learnyounode-command">npm install -g learnyounode</code>
           </div>
           <div id="how-to-npm" class="workshopper">
-            <h2><a href="https://github.com/npm/how-to-npm" target="_blank">How to npm</a></h2>
+            <h3><a href="https://github.com/npm/how-to-npm" target="_blank">How to npm</a></h3>
             <p data-i18n="workshopper-how-to-npm">Learn how to use and create npm modules.</p>
             <code>npm install -g how-to-npm</code>
           </div>
           <div id="streamadventure" class="workshopper">
-            <h2><a href="https://www.github.com/substack/stream-adventure" target="_blank">stream-adventure</a></h2>
+            <h3><a href="https://www.github.com/substack/stream-adventure" target="_blank">stream-adventure</a></h3>
             <p><span data-i18n="workshopper-streamadventure">Learn to compose streaming interfaces with </span><code>.pipe()</code><span data-i18n="workshopper-streamadventure2">.</span></p>
             <code>npm install -g stream-adventure</code>
           </div>
@@ -173,63 +173,63 @@
 
     <div class="container elective-workshoppers" style="background-color: #fff;">
       <div class="third">
-        <h1 data-i18n="index-workshoppers-elective-header">Electives</h1>
+        <h2 data-i18n="index-workshoppers-elective-header">Electives</h2>
         <p data-i18n="index-workshoppers-elective-info">Workshoppers on popular libraries or styles of writing Node.js.</p>
         <p><span data-i18n="index-workshoppers-elective-link-pre">Stuck? Ask a question in the </span> <a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" data-i18n="index-workshoppers-elective-link-text">discussion</a><span data-i18n="index-workshoppers-elective-link-post">.</span></p>
       </div>
       <div class="third">
         <div id="functionaljavascript" class="workshopper">
-          <h2><a href="https://github.com/timoxley/functional-javascript-workshop" target="_blank">Functional Javascript</a></h2>
+          <h3><a href="https://github.com/timoxley/functional-javascript-workshop" target="_blank">Functional Javascript</a></h3>
           <p data-i18n="workshopper-functionaljavascript">Learn fundamental functional programming features of JavaScript in vanilla ES5.</p>
           <code>npm install -g functional-javascript-workshop</code>
         </div>
         <div id="levelmeup" class="workshopper">
-          <h2><a href="https://github.com/rvagg/levelmeup" target="_blank">Level Me Up Scotty!</a></h2>
+          <h3><a href="https://github.com/rvagg/levelmeup" target="_blank">Level Me Up Scotty!</a></h3>
           <p data-i18n="workshopper-levelmeup">Learn to use leveldb, a simple key/value store with a vibrant package.</p>
           <code>npm install -g levelmeup</code>
         </div>
         <div id="expressworks" class="workshopper">
-          <h2><a href="https://github.com/azat-co/expressworks" target="_blank">ExpressWorks</a></h2>
+          <h3><a href="https://github.com/azat-co/expressworks" target="_blank">ExpressWorks</a></h3>
           <p data-i18n="workshopper-expressworks">Learn the basics of the Express.js framework.</p>
           <code>npm install -g expressworks</code>
         </div>
         <div id="makemehapi" class="workshopper">
-          <h2><a href="https://github.com/spumko/makemehapi" target="_blank">Make Me Hapi</a></h2>
+          <h3><a href="https://github.com/spumko/makemehapi" target="_blank">Make Me Hapi</a></h3>
           <p data-i18n="workshopper-makemehapi">Learn all about hapi through a series of challenges.</p>
           <code>npm install -g makemehapi</code>
         </div>
         <div id="promise-it-wont-hurt" class="workshopper">
-          <h2><a href="https://github.com/stevekane/promise-it-wont-hurt" target="_blank">Promise It Won&apos;t Hurt</a></h2>
+          <h3><a href="https://github.com/stevekane/promise-it-wont-hurt" target="_blank">Promise It Won&apos;t Hurt</a></h3>
           <p data-i18n="workshopper-promise-it-wont-hurt">Learn to use promises in JavaScript to handle async operations.</p>
           <code>npm install -g promise-it-wont-hurt</code>
         </div>
         <div id="async-you" class="workshopper">
-          <h2><a href="https://github.com/bulkan/async-you" target="_blank">Async You</a></h2>
+          <h3><a href="https://github.com/bulkan/async-you" target="_blank">Async You</a></h3>
           <p data-i18n="workshopper-async-you">Learn to use the async package.</p>
           <code>npm install -g async-you</code>
         </div>
         <div id="nodebot-workshop" class="workshopper">
-          <h2><a href="https://github.com/tableflip/nodebot-workshop" target="_blank">NodeBot Workshop</a></h2>
+          <h3><a href="https://github.com/tableflip/nodebot-workshop" target="_blank">NodeBot Workshop</a></h3>
           <p data-i18n="workshopper-nodebot-workshop">Make robots with the johnny-five api.</p>
           <code>npm install -g nodebot-workshop</code>
         </div>
         <div id="goingnative" class="workshopper">
-          <h2><a href="https://github.com/rvagg/goingnative" target="_blank">Going Native</a></h2>
+          <h3><a href="https://github.com/rvagg/goingnative" target="_blank">Going Native</a></h3>
           <p data-i18n="workshopper-goingnative">An exploration of Node.js from the underside: native C++ add-ons.</p>
           <code>npm install -g goingnative</code>
         </div>
         <div id="planetproto" class="workshopper">
-          <h2><a href="https://github.com/sporto/planetproto" target="_blank">Planet Proto</a></h2>
+          <h3><a href="https://github.com/sporto/planetproto" target="_blank">Planet Proto</a></h3>
           <p data-i18n="workshopper-planetproto">Understanding JavaScript Prototypes</p>
           <code>npm install -g planetproto</code>
         </div>
         <div id="webgl-workshop" class="workshopper">
-          <h2><a href="https://github.com/stackgl/webgl-workshop" target="_blank">WebGL Workshop</a></h2>
+          <h3><a href="https://github.com/stackgl/webgl-workshop" target="_blank">WebGL Workshop</a></h3>
           <p data-i18n="workshopper-webgl-workshop">Learn the basics of WebGL in small, manageable chunks.</p>
           <code>npm install -g webgl-workshop</code>
         </div>
         <div id="test-anything" class="workshopper">
-          <h2><a href="https://github.com/finnp/test-anything" target="_blank">Test Anything</a></h2>
+          <h3><a href="https://github.com/finnp/test-anything" target="_blank">Test Anything</a></h3>
           <p data-i18n="workshopper-test-anything">Learn to test your code</p>
           <code>npm install -g test-anything</code>
         </div>
@@ -238,57 +238,57 @@
 
       <div class="third">
         <div id="shader-school" class="workshopper">
-          <h2><a href="https://github.com/gl-modules/shader-school" target="_blank">Shader School</a></h2>
+          <h3><a href="https://github.com/gl-modules/shader-school" target="_blank">Shader School</a></h3>
           <p data-i18n="workshopper-shader-school">Learn the fundamentals of graphics programming using GLSL shaders.</p>
           <code>npm install -g shader-school</code>
         </div>
         <div id="bytewiser" class="workshopper">
-          <h2><a href="https://www.github.com/maxogden/bytewiser" target="_blank">Bytewiser</a></h2>
+          <h3><a href="https://www.github.com/maxogden/bytewiser" target="_blank">Bytewiser</a></h3>
           <p data-i18n="workshopper-bytewiser">Learn how to manipulate binary data in node.js and HTML5 browsers.</p>
           <code>npm install -g bytewiser</code>
         </div>
         <div id="bug-clinic" class="workshopper">
-          <h2><a href="https://github.com/othiym23/bug-clinic" target="_blank">Bug Clinic</a></h2>
+          <h3><a href="https://github.com/othiym23/bug-clinic" target="_blank">Bug Clinic</a></h3>
           <p data-i18n="workshopper-bug-clinic">Learn some new tools and techniques as you improve your debugging skills.</p>
           <code>npm install -g bug-clinic</code>
         </div>
         <div id="browserify-adventure" class="workshopper">
-          <h2><a href="https://github.com/substack/browserify-adventure" target="_blank">Browserify Adventure</a></h2>
+          <h3><a href="https://github.com/substack/browserify-adventure" target="_blank">Browserify Adventure</a></h3>
           <p data-i18n="workshopper-browserify-adventure">Use npm modules and node-style require() in the browser with browserify.</p>
           <code>npm install -g browserify-adventure</code>
         </div>
         <div id="introtowebgl" class="workshopper">
-          <h2><a href="https://github.com/alexmackey/IntroToWebGLWithThreeJS" target="_blank">Intro to WebGL</a></h2>
+          <h3><a href="https://github.com/alexmackey/IntroToWebGLWithThreeJS" target="_blank">Intro to WebGL</a></h3>
           <p data-i18n="workshopper-introtowebgl">Get started with three.js and WebGL.</p>
           <code>npm install -g introtowebgl</code>
         </div>
         <div id="count-to-6" class="workshopper">
-          <h2><a href="https://github.com/domenic/count-to-6" target="_blank">Count to 6</a></h2>
+          <h3><a href="https://github.com/domenic/count-to-6" target="_blank">Count to 6</a></h3>
           <p data-i18n="workshopper-count-to-6">Learn how to use some features from ES6, the next version of JavaScript.</p>
           <code>npm install -g count-to-6</code>
         </div>
         <div id="kick-off-koa" class="workshopper">
-          <h2><a href="https://github.com/koajs/kick-off-koa" target="_blank">Kick off Koa</a></h2>
+          <h3><a href="https://github.com/koajs/kick-off-koa" target="_blank">Kick off Koa</a></h3>
           <p data-i18n="workshopper-kick-off-koa">Getting started with Koa, the next generation web framework for Node.js.</p>
           <code>npm install -g kick-off-koa</code>
         </div>
         <div id="lololodash" class="workshopper">
-          <h2><a href="https://github.com/mdunisch/lololodash" target="_blank">LololoDash</a></h2>
+          <h3><a href="https://github.com/mdunisch/lololodash" target="_blank">LololoDash</a></h3>
           <p data-i18n="workshopper-lololodash">Learn Lo-Dash (fork of underscore) to handle your arrays and objects simple!</p>
           <code>npm install -g lololodash</code>
         </div>
         <div id="learnyoucouchdb" class="workshopper">
-          <h2><a href="https://github.com/robertkowalski/learnyoucouchdb" target="_blank">learnyoucouchdb</a></h2>
+          <h3><a href="https://github.com/robertkowalski/learnyoucouchdb" target="_blank">learnyoucouchdb</a></h3>
           <p data-i18n="workshopper-learnyoucouchdb">Learn about CouchDB - the database that completely embraces the web</p>
           <code>npm install -g learnyoucouchdb</code>
         </div>
         <div id="learnuv" class="workshopper">
-          <h2><a href="https://github.com/thlorenz/learnuv" target="_blank">learnuv</a></h2>
+          <h3><a href="https://github.com/thlorenz/learnuv" target="_blank">learnuv</a></h3>
           <p data-i18n="workshopper-learnuv">Learn uv for fun and profit, a self guided workshop to the library that powers Node.js.</p>
           <code>git clone https://github.com/thlorenz/learnuv.git &amp;&amp; cd learnuv &amp;&amp; npm install</code>
         </div>
         <div id="learn-generators" class="workshopper">
-          <h2><a href="https://github.com/isRuslan/learn-generators" target="_blank">Learn Generators</a></h2>
+          <h3><a href="https://github.com/isRuslan/learn-generators" target="_blank">Learn Generators</a></h3>
           <p data-i18n="workshopper-learn-generators">An Intro to JavaScript ES6 Generators.</p>
           <code>npm install -g learn-generators</code>
         </div>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         </div>
       </div>
     </header>
-
+    <div id="main" name="main" role="main">
     <div class="container workshop-header" style="background-color: #fff;">
       <div class="full">
         <h2 data-i18n="index-workshop-header">Workshops</h2>
@@ -295,7 +295,7 @@
 
         </div>
       </div>
-
+    </div>
     <div class="container" style="background-color: #fff;">
       <footer>
         <div class="third">

--- a/js/lang.js
+++ b/js/lang.js
@@ -80,5 +80,21 @@ function addTranslationNav(selectedLang, languages) {
   Object.keys(languages).forEach(function(key) {
     createLangButton(key, languages[key], selectedLang).appendTo(nav)
   })
-  nav.insertBefore("header > *:first-child")
+  $('header > *:first-child')
+    .before('<a class="skip" href="#main">Skip to Content</a>')
+    .before(nav)
 }
+
+// skip navigation polyfill, partly from: http://www.nczonline.net/blog/2013/01/15/fixing-skip-to-content-links/
+$(window)
+  .on('hashchange', function(event) {
+    console.log(11)
+    var element = document.getElementById(location.hash.substring(1))
+    if (element) {
+      if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {
+        element.tabIndex = -1
+      }
+      element.focus()
+    }
+  })
+  .trigger('hashchange')

--- a/js/lang.js
+++ b/js/lang.js
@@ -13,7 +13,7 @@ xhr({url: 'languages/languages.json', json: true}, function (error, response, re
   
   $(document.body).on( "click", "a.switch-lang", function(e) {
     e.preventDefault()
-    var lang = $(e.target).attr('data-lang')
+    var lang = $(e.target).attr('lang')
     translateToLang(lang, languages, i18nSpecifiers)
     return false
   })
@@ -68,7 +68,7 @@ function translateHTML(lang, translation, i18nSpecifiers) {
 function createLangButton(lang, langName, selectedLang) {
   return $('<li class="nav-lang-' + lang + '">')
     .toggleClass("selected", lang === selectedLang)
-    .html(lang === selectedLang ? langName : '<a href="#" class="switch-lang" data-lang="' + lang + '">' + langName + '</a>')
+    .html(lang === selectedLang ? langName : '<a href="#" class="switch-lang" lang="' + lang + '">' + langName + '</a>')
 }
 
 function addTranslationNav(selectedLang, languages) {

--- a/js/lang.js
+++ b/js/lang.js
@@ -88,7 +88,6 @@ function addTranslationNav(selectedLang, languages) {
 // skip navigation polyfill, partly from: http://www.nczonline.net/blog/2013/01/15/fixing-skip-to-content-links/
 $(window)
   .on('hashchange', function(event) {
-    console.log(11)
     var element = document.getElementById(location.hash.substring(1))
     if (element) {
       if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {

--- a/js/main.js
+++ b/js/main.js
@@ -134,7 +134,7 @@ function makeMap(data) {
   sorted.forEach(fixLatLong)
 
   var optionsJSON = ["name", "website", "startdate", "state"]
-  var template = "<p class='event'>{{startdate}} <a class='{{state}}' href='{{website}}'"
+  var template = "<p class='event'><time>{{startdate}}</time> <a class='{{state}}' href='{{website}}'"
     + " target='_blank'>{{name}}</a><p>"
 
   var map = Sheetsee.loadMap("map")
@@ -148,6 +148,7 @@ function makeMap(data) {
       marker.setIcon(L.divIcon({
               // Specify a class name we can refer to in CSS.
               className: 'past-event',
+        
               // Set a markers width and height.
               iconSize: [7, 7]
           }))

--- a/js/table.js
+++ b/js/table.js
@@ -102,7 +102,7 @@ function generateMonthTable( date ) {
   var weekDayNumber  = firstDay.getDay()
 
   $('#calendar-goes-here').append(monthTable)
-  monthTable.before('<h2 data-month="' + date.getFullYear() + '-' + eventMonthName + '">' + eventMonthName + ' ' + date.getFullYear() + '</h2>')
+  monthTable.before('<h3 data-month="' + date.getFullYear() + '-' + eventMonthName + '">' + eventMonthName + ' ' + date.getFullYear() + '</h3>')
 
   // Add month calendar header
   monthTableBody.append('<tr class="header"></tr>')

--- a/style.css
+++ b/style.css
@@ -3,8 +3,8 @@ body {margin: 0; padding: 0; overflow: auto; font-family: Source Sans Pro; color
 /*#ee3c30 rgb(238, 60, 48)*/
 /*#AAA688*/
 
-h2 {font-size: 3em; margin: 10px 0;}
-h3 {font-size: 2em;}
+h1, .big-heading {font-size: 3em; margin: 10px 0;}
+h2, h3 {font-size: 2em;}
 h3 a { color: black; }
 
 code {font-family: Source Code Pro; font-size: 12px; background: #fafafa; border-radius: 3px; padding: 3px 5px; line-height: 20px;}
@@ -108,7 +108,7 @@ ul.nav-lang li.selected {text-decoration: none; color: #666;}
 
 .third {width: 30%; display: inline-block; vertical-align: top; }
 .third + .third {padding-left: 30px;}
-.third p, .third h3, .third h2 {margin-top: 0; line-height: 28px;}
+.third p, .third h3, .third h4 {margin-top: 0; line-height: 28px;}
 
 .full {width: 63%; text-align: center; margin: 0 auto;}
 .full p {font-size: 26px;}
@@ -119,14 +119,14 @@ ul.nav-lang li.selected {text-decoration: none; color: #666;}
 .two-thirds + .third {padding-left: 30px;}
 .third + .two-thirds {padding-left: 30px;}
 
-.core-workshoppers h2,
-.elective-workshoppers h2 {font-weight: 500;}
+.core-workshoppers h3,
+.elective-workshoppers h3 {font-weight: 500; font-size: 3em; margin: 10px 0}
 
-.workshopper h3 a { border-radius: 3px; font-size: 20px; padding: 6px 10px; font-family: Source Code Pro; font-weight: 500; text-decoration: none; display: block; border: none;}
-.elective-workshoppers h3 a {background: #333; color: #fff;}
-.core-workshoppers h3 a {background: #FFE51F; color: #333; }
-.elective-workshoppers h3 a:hover {background: #000; }
-.core-workshoppers h3 a:hover {background: #F7DA03;}
+.workshopper h4 a { border-radius: 3px; font-size: 20px; padding: 6px 10px; font-family: Source Code Pro; font-weight: 500; text-decoration: none; display: block; border: none;}
+.elective-workshoppers h4 a {background: #333; color: #fff;}
+.core-workshoppers h4 a {background: #FFE51F; color: #333; }
+.elective-workshoppers h4 a:hover {background: #000; }
+.core-workshoppers h4 a:hover {background: #F7DA03;}
 
 .workshopper {padding-bottom: 20px;}
 .workshopper p{ min-height: 2.8em;}
@@ -177,6 +177,7 @@ footer .container {padding: 0 40px;}
 .hexdex img.hex {width: 240px; padding: 10px;}
 
 @media (max-width: 768px) {
+  h1 { font-size: 2.0em; }
   .container {padding: 20px;}
   .first-photo {background-image: none;}
   p {font-size: 1em;}
@@ -203,11 +204,11 @@ footer .container {padding: 0 40px;}
   header .full { width: 80%; }
   .full p { font-size: 16px; }
   h2 { font-size: 18px; }
-  h3 { font-size: 16px; }
+  h4 { font-size: 16px; }
   .container { padding: 20px; }
   header .container { padding: 20px; }
   .full { width: 95%; }
-  .core-workshoppers h3 a, .elective-workshoppers h3 a { font-size: 16px; }
+  .core-workshoppers h4 a, .elective-workshoppers h4 a { font-size: 16px; }
   ul.inner-nav li {display: inline-block; line-height: 3em;}
   .window-pane { display: none; }
 }

--- a/style.css
+++ b/style.css
@@ -3,9 +3,9 @@ body {margin: 0; padding: 0; overflow: auto; font-family: Source Sans Pro; color
 /*#ee3c30 rgb(238, 60, 48)*/
 /*#AAA688*/
 
-h1 {font-size: 3em; margin: 10px 0;}
-h2 {font-size: 2em;}
-h2 a { color: black; }
+h2 {font-size: 3em; margin: 10px 0;}
+h3 {font-size: 2em;}
+h3 a { color: black; }
 
 code {font-family: Source Code Pro; font-size: 12px; background: #fafafa; border-radius: 3px; padding: 3px 5px; line-height: 20px;}
 
@@ -28,7 +28,7 @@ header .big-link { color: #333; font-weight: bold; border-color: #333;}
 header .big-link:hover { border-color: #777; color: #777; }
 header h1 { text-transform: uppercase; }
 
-header h3 { font-size: 1.5em; font-weight: 500; margin: 10px 0 0 0; }
+header p { font-size: 1.5em; font-weight: 500; margin: 10px 0 0 0; }
 header .full { width: 47%; }
 header .subtitle { margin-bottom: 20px; letter-spacing: .05em; }
 header .nav a {color: #333; border-color: #fff; border: none;}
@@ -57,7 +57,7 @@ header .container {padding: 100px 40px;}
 .container {padding: 60px 40px;}
 
 .get-started code {font-size: 24px; background: #fff;}
-.get-started h2 {margin-top: 0;}
+.get-started h3 {margin-top: 0;}
 
 .window-pane {height: 400px; width: 100%; background-image: url('images/hero3.jpg'); background-position: 0 -200px; background-size: 100%; background-repeat: no-repeat;}
 .caption {color: #fff; font-size: 11px; padding: 40px; display: inline-block; opacity: .5;}
@@ -108,7 +108,7 @@ ul.nav-lang li.selected {text-decoration: none; color: #666;}
 
 .third {width: 30%; display: inline-block; vertical-align: top; }
 .third + .third {padding-left: 30px;}
-.third h3, .third h2, .third h1 {margin-top: 0; line-height: 28px;}
+.third p, .third h3, .third h2 {margin-top: 0; line-height: 28px;}
 
 .full {width: 63%; text-align: center; margin: 0 auto;}
 .full p {font-size: 26px;}
@@ -119,14 +119,14 @@ ul.nav-lang li.selected {text-decoration: none; color: #666;}
 .two-thirds + .third {padding-left: 30px;}
 .third + .two-thirds {padding-left: 30px;}
 
-.core-workshoppers h1,
-.elective-workshoppers h1 {font-weight: 500;}
+.core-workshoppers h2,
+.elective-workshoppers h2 {font-weight: 500;}
 
-.workshopper h2 a { border-radius: 3px; font-size: 20px; padding: 6px 10px; font-family: Source Code Pro; font-weight: 500; text-decoration: none; display: block; border: none;}
-.elective-workshoppers h2 a {background: #333; color: #fff;}
-.core-workshoppers h2 a {background: #FFE51F; color: #333; }
-.elective-workshoppers h2 a:hover {background: #000; }
-.core-workshoppers h2 a:hover {background: #F7DA03;}
+.workshopper h3 a { border-radius: 3px; font-size: 20px; padding: 6px 10px; font-family: Source Code Pro; font-weight: 500; text-decoration: none; display: block; border: none;}
+.elective-workshoppers h3 a {background: #333; color: #fff;}
+.core-workshoppers h3 a {background: #FFE51F; color: #333; }
+.elective-workshoppers h3 a:hover {background: #000; }
+.core-workshoppers h3 a:hover {background: #F7DA03;}
 
 .workshopper {padding-bottom: 20px;}
 .workshopper p{ min-height: 2.8em;}
@@ -187,7 +187,7 @@ footer .container {padding: 0 40px;}
   header img {width: 100%; padding: 0;}
   header h1 { font-size: 2.5em; margin-top: 0; }
   header h1 span {margin: 0 -3.8px;}
-  header h3 {font-size: 1em; }
+  header p {font-size: 1em; }
   #map {margin: 0; padding: 0; width: 100%;}
   .window-pane {background-position: 0 0; height: 200px;}
   footer ul {width: 100%;}
@@ -202,12 +202,12 @@ footer .container {padding: 0 40px;}
   header .subtitle { margin: 0 auto 20px; width: 75%; }
   header .full { width: 80%; }
   .full p { font-size: 16px; }
-  h1 { font-size: 18px; }
-  h2 { font-size: 16px; }
+  h2 { font-size: 18px; }
+  h3 { font-size: 16px; }
   .container { padding: 20px; }
   header .container { padding: 20px; }
   .full { width: 95%; }
-  .core-workshoppers h2 a, .elective-workshoppers h2 a { font-size: 16px; }
+  .core-workshoppers h3 a, .elective-workshoppers h3 a { font-size: 16px; }
   ul.inner-nav li {display: inline-block; line-height: 3em;}
   .window-pane { display: none; }
 }

--- a/style.css
+++ b/style.css
@@ -197,9 +197,10 @@ footer .container {padding: 0 40px;}
 }
 
 @media only screen and (max-width : 1366px) {
+  h1, .big-heading { font-size: 2.0em}
   .get-started code { font-size: 12px; }
   header img { height: 75px; }
-  header h1 { font-size: 40px; margin-top: 0; }
+  header h1 { font-size: 2.0em; margin-top: 0; }
   header .subtitle { margin: 0 auto 20px; width: 75%; }
   header .full { width: 80%; }
   .full p { font-size: 16px; }

--- a/style.css
+++ b/style.css
@@ -211,3 +211,25 @@ footer .container {padding: 0 40px;}
   ul.inner-nav li {display: inline-block; line-height: 3em;}
   .window-pane { display: none; }
 }
+
+/* skip naviation links */
+.skip {
+    position: absolute;
+    top: -1000px;
+    left: -1000px;
+    height: 1px;
+    width: 1px;
+    text-align: left;
+    overflow: hidden;
+    background-color: white;
+}
+
+a.skip:active, 
+a.skip:focus, 
+a.skip:hover {
+    left: 0; 
+    top: 0;
+    width: auto; 
+    height: auto; 
+    overflow: visible; 
+}

--- a/style.css
+++ b/style.css
@@ -23,15 +23,10 @@ hr {border: 2px solid #333; margin: 0;}
 
 header {color: #333; background-image: url('images/test-bg.png'); background-size: 25%; background-position: 0 -100px; z-index: -1; display: block; background-color: #FFE51F; background-blend-mode: multiply; }
 header h1 {font-size: 500%; font-weight: 900; margin-bottom: 0px; margin-top: 20px; line-height: 1;}
-header h1:hover { cursor: pointer; cursor: grabbing; cursor: -webkit-grabbing; }
-header h1 span { display: inline-block; margin: 0 -0.1em; padding: 0; overflow: hidden; width: auto; transition: all 0.3s cubic-bezier(0.455, 0.03, 0.515, 0.955); line-height: 1; }
 
 header .big-link { color: #333; font-weight: bold; border-color: #333;}
 header .big-link:hover { border-color: #777; color: #777; }
-header h1 span.apostrophe { max-width: 0px; opacity: 0;}
-header h1 span.apostrophe:before { content: "\2019";}
-header h1 span.c { }
-header h1 span.h { transition-duration: 0.2s; max-width: 100px; }
+header h1 { text-transform: uppercase; }
 
 header h3 { font-size: 1.5em; font-weight: 500; margin: 10px 0 0 0; }
 header .full { width: 47%; }
@@ -180,12 +175,6 @@ footer p {margin: 0; padding: 0;}
 footer .container {padding: 0 40px;}
 
 .hexdex img.hex {width: 240px; padding: 10px;}
-
-@media (min-width: 1366px) {
-  header h1:hover span.apostrophe { margin-right: -12px; max-width: 100px; opacity: 1; }
-  header h1:hover span.c { padding-left: 44px; margin-right: -12px; }
-  header h1:hover span.h { max-width: 0px; opacity: 0;}
-}
 
 @media (max-width: 768px) {
   .container {padding: 20px;}


### PR DESCRIPTION
Hey everyone,

this PR fixes a lot of a11y issues and especially improves the usage with screen readers.

The improvements include:
* Make NodeSchool heading readable
* Some ARIA/HTML5 mark up
* Hide map from screen readers (for now)
* [Skip to content link](http://webaim.org/techniques/skipnav/)
* Fix Heading outlines

Right now this removes the "Node's Cool" animation from the first page. Basically the problem was that this made screen readers pronounce NodeSchool like "N - O - D - E Apostrophs C - ....". I thought about fixing it, but then just removed it. Maybe someone can re-add it later in a screenreadable way.

Otherwise there are only slight visual changes to the heading sizes.

Best,
Finn