### PR TITLE
Renamed the variables in Google Analytics script

### DIFF
--- a/about.html
+++ b/about.html
@@ -113,14 +113,13 @@
     <script type="text/javascript" src="js/dependencies.js"></script>
     <script type="text/javascript" src="js/lang.js"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>

--- a/building-workshops.html
+++ b/building-workshops.html
@@ -90,14 +90,13 @@
     <script type="text/javascript" src="js/dependencies.js"></script>
     <script type="text/javascript" src="js/lang.js"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>

--- a/chapters.html
+++ b/chapters.html
@@ -98,14 +98,13 @@
     <script type="text/javascript" src="js/lang.js"></script>
     <script type="text/javascript" src="js/chapters.js"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -101,14 +101,13 @@
     <script type="text/javascript" src="js/lang.js"></script>
 
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>

--- a/hexdex.html
+++ b/hexdex.html
@@ -130,14 +130,13 @@
     <script type="text/javascript" src="js/dependencies.js"></script>
     <script type="text/javascript" src="js/lang.js"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>

--- a/host.html
+++ b/host.html
@@ -124,14 +124,13 @@
     <script type="text/javascript" src="js/dependencies.js"></script>
     <script type="text/javascript" src="js/lang.js"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -363,14 +363,13 @@
     <script type="text/javascript" src="js/lang.js"></script>
 
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>

--- a/mentor-at-event.html
+++ b/mentor-at-event.html
@@ -124,14 +124,13 @@
     <script type="text/javascript" src="js/dependencies.js"></script>
     <script type="text/javascript" src="js/lang.js"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(s,c,h,O,o,l){s.GoogleAnalyticsObject=h;s[h]||(s[h]=function(){
+      (s[h].q=s[h].q||[]).push(arguments)});s[h].l=+new Date;o=c.createElement(O);
+      l=c.getElementsByTagName(O)[0];o.src='//www.google-analytics.com/analytics.js';
+      l.parentNode.insertBefore(o,l)}(window,document,'ga','script');
 
       ga('create', 'UA-49267600-1', 'nodeschool.io');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>


### PR DESCRIPTION
`i` `s` `o` `g` `r` `a` `m` -> `s` `c` `h` `O` `o` `l`

================

The code is generated by using [isogram](https://github.com/shinnn/isogram), a well-tested Google Analytics easter egg generator used in:

* [gulpjs.com](http://gulpjs.com/) - `g` `u` `l` `p` `j` `s`
* [Jekyll website](http://jekyllrb.com/) - `j` `e` `k` `y` `l` `L`
* [cssnext website](https://cssnext.github.io/) - `c` `s` `s` `N` `e` `x` `t`
* [and so on](https://github.com/shinnn/isogram/tree/1363db298b1d9c015581094ccbe8de5f2c2ecf7f#websites-using-isogram)

If you prefer other characters, I'll update the commit. For example:

`n` `o` `d` `e` `j` `s`

```js
!function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
(n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
s=o.getElementsByTagName(e)[0];j.src='//www.google-analytics.com/analytics.js';
s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
```