### PR TITLE
Add google analytics tracking for workshopper links clicks

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -28,3 +28,13 @@ function showNearEvents(data) {
 function writeCount(count) {
   $('#event-count .cnt').text(count)
 }
+
+// init google analytics tracking events for clicks on workshop external links
+$('#workshopper-list, .elective-workshoppers')
+  // assuming current layout (first .third used for info)
+  .find('.third:not(:eq(0))')
+  .on('click', 'a', function (e) {
+    // assuming github.com/username/workshopper
+    var workshopperId = $(this).attr('href').split('/').slice(-1)[0];
+    ga('send', 'event', 'workshopper', 'click', workshopperId);
+  });


### PR DESCRIPTION
As discussed in #337.
Have some doubts whether this code is good enough.
It's a bit fragile, because:
1) it relies on id & class selectors for containers, as well as layout to be the same (with first `.third` item to contain info only, and not track those link clicks [although we could totally track how many people are following issues link when willing to ask a question])
2) it relies on href to provide workshopperId (which would be the reponame, given all links are to github)
Would love to hear feedback and modify code accordingly.