### PR TITLE
Add esnext-generation workshopper

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,11 @@
           <p data-i18n="workshopper-webgl-workshop">Learn the basics of WebGL in small, manageable chunks.</p>
           <code>npm install -g webgl-workshop</code>
         </div>
+        <div id="esnext-generation" class="workshopper">
+          <h4><a href="https://github.com/jesstelford/esnext-generation" target="_blank">ESNext Generation</a></h4>
+          <p data-i18n="workshopper-esnext-generation">Intro to ES6 Iterators, their use, and how they relate to Generators.</p>
+          <code>npm install -g esnext-generation</code>
+        </div>
         <div id="test-anything" class="workshopper">
           <h4><a href="https://github.com/finnp/test-anything" target="_blank">Test Anything</a></h4>
           <p data-i18n="workshopper-test-anything">Learn to test your code</p>
@@ -277,7 +282,7 @@
           <p data-i18n="workshopper-tower-of-babel">Show you through a series of exercises that introduce you to ES6 features.</p>
           <code>npm install tower-of-babel -g</code>
         </div>
-        
+
       </div>
 
       <div class="third">


### PR DESCRIPTION
As this leads into the `learn-generators` workshopper, I have attempted to place
it before `learn-generators` in the page layout.