### PR TITLE
NodeSchool Costa Rica - Organizers & Website [update]

### DIFF
--- a/chapters/costarica.json
+++ b/chapters/costarica.json
@@ -4,9 +4,19 @@
   "country": "CRI",
   "region": "Latin America",
   "organizers": [
-    "gaboesquivel"
+    "gaboesquivel",
+    "yeco",
+    "laubits",
+    "brolag",
+    "stevenperez",
+    "kevinblanco",
+    "laurensortiz",
+    "jarias",
+    "rubenabix",
+    "cayasso",
+    "avenidanet"
   ],
-  "website": "http://meetup.com/costaricajs",
+  "website": "http://nodeschool.io/costarica/",
   "twitter": "costaricajs",
   "repo": "http://github.com/nodeschool/costarica"
 }


### PR DESCRIPTION
This PR pretends to update the website and organizers' information related to NodeShool Costa Rica.

FYI - @gaboesquivel 