### PR TITLE
Add a how-to-markdown workshopper.

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,11 @@
             <p><span data-i18n="workshopper-streamadventure">Learn to compose streaming interfaces with </span><code>.pipe()</code><span data-i18n="workshopper-streamadventure2">.</span></p>
             <code>npm install -g stream-adventure</code>
           </div>
+          <div id="how-to-markdown" class="workshopper">
+            <h4><a class="js-workshop-link" href="https://github.com/denysdovhan/how-to-markdown" target="_blank">how-to-markdown</a></h4>
+            <p data-i18n="workshopper-how-to-markdown">Learn how to start using Markdown — a lightweight markup language with plain text formatting syntax.</p>
+            <code>npm install -g how-to-markdown</code>
+          </div>
         </div>
       </div>
 

--- a/languages/ru.json
+++ b/languages/ru.json
@@ -71,6 +71,7 @@
   "workshopper-scope-chains-closures": "Изучите в деталях, что такое области видимости, замыкания и сборщик мусора.",
   "workshopper-streamadventure": "Научитесь создавать потоковые интерфейсы с помощью",
   "workshopper-streamadventure2": ".",
+  "workshopper-how-to-markdown": "Научитесь использовать Markdown — легкий язык разметки з помощью простого текста.",
   "workshopper-functionaljavascript": "Узнайте о новых возможностях функционального программирования на чистом JavaScript из стандарта ES5",
   "workshopper-levelmeup": "Научитесь использовать leveldb — простое хранилище типа ключ/значение.",
   "workshopper-expressworks": "Получите базовые знания о фреймворке Express.js.",

--- a/languages/uk.json
+++ b/languages/uk.json
@@ -67,6 +67,7 @@
     "workshopper-gitit": "Вивчіть основи роботи з Git та GitHub.",
     "workshopper-streamadventure": "Навчитися створювати потокові інтерфейси за допомогою",
     "workshopper-streamadventure2": ".",
+    "workshopper-how-to-markdown": "Навчіться використовувати Markdown — легку мову розмітки з використанням простого тексту.",
     "workshopper-functionaljavascript": "Вивчіть основні особливості функціонального програмування на JavaScript (ES5).",
     "workshopper-levelmeup": "Навчіться використовувати LevelDB, простий key/value сховище з багатою екосистемою.",
     "workshopper-expressworks": "Вивчіть основи фреймворку Express.js.",


### PR DESCRIPTION
I've built a workshopper about Markdown called [`how-to-markdown`](https://github.com/denysdovhan/how-to-markdown):

![image](https://cloud.githubusercontent.com/assets/3459374/14460480/80c3229a-00c6-11e6-974a-a553c3209d02.png)

@martinheidegger said [it's okay to add this to Core section](https://gitter.im/nodeschool/organizers?at=570bb9f2ddb5a2cf3bbb46f2). 