### PR TITLE
Update Vancouver organizers

### DIFF
--- a/chapters/vancouver.json
+++ b/chapters/vancouver.json
@@ -3,7 +3,7 @@
   "location": "Vancouver, BC",
   "country": "CA",
   "region": "North America",
-  "organizers": ["sintaxi", "notmatt", "afabbro", "lvivier", "gyaresu"],
+  "organizers": ["lvivier", "gyaresu", "qard"],
   "website": "http://nodeschool.io/vancouver/",
   "repo": "http://github.com/nodeschool/vancouver"
 }


### PR DESCRIPTION
This PR is just some housekeeping to update the Vancouver organizers to match the [nodeschool/vancouver team](https://github.com/orgs/nodeschool/teams/vancouver).