### PR TITLE
corrected data-i18n tag for bacon-love workshop

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
         </div>
         <div id="bacon-love" class="workshopper">
           <h4><a class="js-workshop-link" href="https://github.com/mikaelbr/bacon-love" target="_blank">bacon-love</a></h4>
-          <p data-i18n="workshopper-currying">Learn concepts of Functional and Reactive Programming using the Bacon.js library.</p>
+          <p data-i18n="workshopper-bacon-love">Learn concepts of Functional and Reactive Programming using the Bacon.js library.</p>
           <code>npm install -g bacon-love</code>
         </div>
       </div>


### PR DESCRIPTION
Running ```npm run validate-html``` reveals that the i18n tag for both bacon-love and Currying were the same.  This resulted in the improper text displaying for the bacon-love description.  This PR corrects the issue.