### PR TITLE
Add recommended min Node.js version

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
         <div class="third">
           <div id="get-going">
             <h3 data-i18n="index-get-going-header">Get Going &#x2014;</h3>
-            <p><span data-i18n="index-get-going-info">You&#x2019;ll need</span> <a href="http://nodejs.org">Node.js</a> <span data-i18n="index-get-going-info2">on your computer to get started
+            <p><span data-i18n="index-get-going-info">You&#x2019;ll need</span> <a href="http://nodejs.org">Node.js</a> <span data-i18n="index-get-going-info2">(v6.0.2 or higher) on your computer to get started
     with each of these. Then use</span> <a href="http://npmjs.org">npm</a> <span data-i18n="index-get-going-info3">(it comes with Node) to install each
     module with the command below it. Once installed,
     simply type the workshopper&#x2019;s name to launch.</span></p>


### PR DESCRIPTION
Node.js version 'recommended for most users' is currently v4.5.0 LTS. Workshopper menu selection bug (see Node.js issue [#5384](https://github.com/nodejs/node/issues/5384)) fixed in v6.2.0, so current version is recommended for NodeSchool users.