### PR TITLE
Removed "/" from title of "JS best practices"

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@
           <code>npm install -g less-is-more</code>
         </div>
         <div id="js-best-practices" class="workshopper">
-          <h4><a class="js-workshop-link" href="https://github.com/excellalabs/js-best-practices-workshopper" target="_blank" rel="noreferrer noopener">/JavaScript best practices</a></h4>
+          <h4><a class="js-workshop-link" href="https://github.com/excellalabs/js-best-practices-workshopper" target="_blank" rel="noreferrer noopener">JavaScript best practices</a></h4>
           <p data-i18n="workshopper-js-best-practices">Learn the best practices of writing clean JavaScript code.</p>
           <code>npm install -g js-best-practices</code>
         </div>


### PR DESCRIPTION
Noticed a typo in the title of the workshopper I added yesterday; just wanted to push a quick fix for that.