### PR TITLE
Update Git-it info

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
           <div id="gitit" class="workshopper">
             <h4><a class="js-workshop-link" href="https://www.github.com/jlord/git-it-electron" target="_blank" rel="noreferrer noopener">git-it</a></h4>
             <p data-i18n="workshopper-gitit">Learn Git and GitHub basics.</p>
-            <code>Download the latest desktop app release</code>
+            <p>Download the <a href="https://github.com/jlord/git-it-electron/releases" target="_blank" rel="noreferrer noopener">latest desktop app release</a>.</p>
           </div>
           <div id="scope-chains-closures" class="workshopper">
             <h4><a href="https://www.github.com/jesstelford/scope-chains-closures" target="_blank" rel="noreferrer noopener">Scope Chains & Closures</a></h4>

--- a/index.html
+++ b/index.html
@@ -195,9 +195,9 @@
             <code>npm install -g javascripting</code>
           </div>
           <div id="gitit" class="workshopper">
-            <h4><a class="js-workshop-link" href="https://www.github.com/jlord/git-it" target="_blank" rel="noreferrer noopener">git-it</a></h4>
+            <h4><a class="js-workshop-link" href="https://www.github.com/jlord/git-it-electron" target="_blank" rel="noreferrer noopener">git-it</a></h4>
             <p data-i18n="workshopper-gitit">Learn Git and GitHub basics.</p>
-            <code>npm install -g git-it</code>
+            <code>Download the latest desktop app release</code>
           </div>
           <div id="scope-chains-closures" class="workshopper">
             <h4><a href="https://www.github.com/jesstelford/scope-chains-closures" target="_blank" rel="noreferrer noopener">Scope Chains & Closures</a></h4>


### PR DESCRIPTION
Heyo! 🍕 

This updates the site to point to the Electron desktop version of Git-it which is the nice fun version that I'm actively maintaining ✨ 

Let me know thoughts on what to put in the space that is supposed to show how to npm install. 

_Preview_ 

<img width="418" alt="screen shot 2017-03-16 at 4 46 43 pm" src="https://cloud.githubusercontent.com/assets/1305617/24017953/69660548-0a68-11e7-9fc0-fbfab9bf306f.png">

_Another option that links to directly to releases page_

<img width="408" alt="screen shot 2017-03-16 at 4 50 28 pm" src="https://cloud.githubusercontent.com/assets/1305617/24018061/cc877940-0a68-11e7-9e8c-907d403b9c02.png">

🔗 https://github.com/workshopper/org/issues/27