### PR TITLE
Update Bangalore chapter to Bengaluru

### DIFF
--- a/chapters/bengaluru.json
+++ b/chapters/bengaluru.json
@@ -1,10 +1,10 @@
 {
-  "name": "Bangalore NodeSchool",
-  "location": "Bangalore",
+  "name": "Bengaluru NodeSchool",
+  "location": "Bengaluru",
   "country": "IN",
   "region": "Asia",
   "organizers": ["abyv", "somesh123", "somsharan"],
   "website": "",
   "twitter": "",
-  "repo": "http://github.com/nodeschool/bangalore"
+  "repo": "http://github.com/nodeschool/bengaluru"
 }


### PR DESCRIPTION
The Bangalore chapter name was renamed to Bengaluru. This update reflects
the change in names on the Nodeschool site.