### PR TITLE
Updated example language code in generate-lang script

### DIFF
--- a/scripts/generate-lang.js
+++ b/scripts/generate-lang.js
@@ -5,7 +5,7 @@ var fs = require('fs')
 var read = require('read')
 var path = require('path')
 
-read({prompt: 'What language code do you want to generate? (e.g. en-US):'}, function(err, language) {
+read({prompt: 'What language code do you want to generate? (e.g. en):'}, function(err, language) {
   if (!language) {
     console.log('Usage:\nnpm run language [language-code]');
     process.exit(1);


### PR DESCRIPTION
#133 Looking at the existing translations, it seemed like the existing languages went with the first column in the referenced table.