### PR TITLE
Adding Code Of Conduct Link

### DIFF
--- a/about.html
+++ b/about.html
@@ -80,6 +80,15 @@
           <p data-i18n="about-info3">In <a href="https://archive.org/details/NodeUp55" target="_blank" rel="noreferrer noopener">episode 55</a> of the NodeUp podcast Mikeal Rogers, Max Ogden and other community members talk about NodeSchools. At Cascadia JS 2014 Jason Rhodes, from Baltimore, <a href="https://www.youtube.com/watch?v=YJ7txKTh3-E" target="_blank" rel="noreferrer noopener">talks about running NodeSchools</a>.</p>
         </div>
       </div>
+
+      <div class="container">
+        <div class="third">
+          <h3 data-i18n="code-of-conduct">Code of conduct</h3>
+        </div>
+        <div class="two-thirds">
+          <p data-i18n="about-info4">NodeSchool organizers must follow the code of conduct outlined in the <a href="https://github.com/nodeschool/organizers/blob/master/code_of_conduct.md">organizers repository</a>. Each NodeSchool chapter is responsible for maintaining their own code of conduct. If you have questions about the code of conduct for a chapter you can open an issue in their associated github repository.</p>
+        </div>
+      </div>
     </div>
     </div>
     <div class="container" style="background-color: #fff;">


### PR DESCRIPTION
#306 I opted to add the code of conduct to the bottom of the about page. If we'd like it to be more prominent I could move it up the about page, or find somewhere else to put it.