### PR TITLE
Extracting footers to file and injecting during build-html script

### DIFF
--- a/about.html
+++ b/about.html
@@ -84,27 +84,7 @@
     </div>
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small>Photos by <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/building-workshops.html
+++ b/building-workshops.html
@@ -61,27 +61,7 @@
     </div>
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small>Photos by <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/chapters.html
+++ b/chapters.html
@@ -47,27 +47,7 @@
     </div>
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small>Photos by <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/events.html
+++ b/events.html
@@ -56,27 +56,7 @@
   </div>
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small>Photos by <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,22 @@
+<div class="third">
+    <p><strong>nodeschool.io</strong></p>
+    <small><span>Photos by</span> <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a><span></span></small>
+</div>
+<div class="two-thirds">
+    <ul>
+      <li><strong data-i18n="footer-contact-header">Contact</strong></li>
+      <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
+      <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
+    </ul>
+    <ul>
+      <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
+      <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
+      <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
+    </ul>
+    <ul>
+      <li><strong data-i18n="footer-about-header">About</strong></li>
+      <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
+      <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
+      <li><a href="https://github.com/nodeschool/nodeschool.github.io/blob/source/LICENSE" data-i18n="footer-about-license">Website license</a></li>
+    </ul>
+ </div>

--- a/hexdex.html
+++ b/hexdex.html
@@ -200,27 +200,7 @@
   </div>
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small>Photos by <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/host.html
+++ b/host.html
@@ -38,27 +38,7 @@
   </div>
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small>Photos by <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -459,28 +459,7 @@
     </section>
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small><span>Photos by</span> <a href="https://www.flickr.com/photos/matthewbergman" target="_blank" rel="noreferrer noopener">Matthew Bergman</a><span></span></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-            <li><a href="https://github.com/nodeschool/nodeschool.github.io/blob/source/LICENSE" data-i18n="footer-about-license">Website license</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/mentor-at-event.html
+++ b/mentor-at-event.html
@@ -95,27 +95,7 @@
 
     <div class="container" style="background-color: #fff;">
       <footer>
-        <div class="third">
-          <p><strong>nodeschool.io</strong></p>
-          <small>Photo by <a href="http://oleharland.com/" target="_blank" rel="noreferrer noopener">Ole Harland</a></small>
-        </div>
-        <div class="two-thirds">
-          <ul>
-            <li><strong data-i18n="footer-contact-header">Contact</strong></li>
-            <li><a href="https://twitter.com/nodeschool" target="_blank" rel="noreferrer noopener">t/@nodeschool</a></li>
-            <li><a href="https://github.com/nodeschool" target="_blank" rel="noreferrer noopener">gh/nodeschool</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-contribute-header">Contribute</strong></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues/new" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-question">Open an Issue</a></li>
-            <li><a href="https://github.com/nodeschool/discussions/issues" target="_blank" rel="noreferrer noopener" data-i18n="footer-contribute-answer">Answer a Question</a></li>
-          </ul>
-          <ul>
-            <li><strong data-i18n="footer-about-header">About</strong></li>
-            <li><a href="building-workshops.html" data-i18n="footer-about-build">Build a workshopper</a></li>
-            <li><a href="host.html" data-i18n="footer-about-host">Host a workshop</a></li>
-          </ul>
-        </div>
+        <!-- content in footer.html added by build-html.js -->
       </footer>
     </div>
 

--- a/scripts/build-html.js
+++ b/scripts/build-html.js
@@ -116,6 +116,12 @@ cmdwatcher('build-html'
 			return console.log('Error while domify %s:\n%s', file, e)
 		}
 
+		var footer = dom.querySelector('footer')
+		if(footer) {
+			var footerHtml = Fs.readFileSync(FOOTER, 'utf8')
+			footer.innerHTML = footerHtml
+		}
+		
 		var list = dom.querySelectorAll('[data-i18n]')
 		if (list) {
 			original = {}
@@ -126,12 +132,6 @@ cmdwatcher('build-html'
 			}
 		}
 		translations['en'] = original
-
-		var footer = dom.querySelector('footer')
-		if(footer) {
-			var footerHtml = Fs.readFileSync(FOOTER, 'utf8')
-			footer.innerHTML = footerHtml
-		}
 
 		var html = dom.querySelector('html')
 		var localeLinks = addLanguageLinks(dom, file, languages)

--- a/scripts/build-html.js
+++ b/scripts/build-html.js
@@ -6,9 +6,10 @@ const jsdom = require('jsdom')
 const mkdirp = require('mkdirp')
 const cmdwatcher = require('./util/cmdwatcher')
 const LANGS = Path.join(__dirname, '../languages/languages.json')
+const FOOTER = Path.join(__dirname, '../footer.html')
 
 function createLangButton(dom, file, lang, langName) {
-  var li = dom.createElement('li')
+var li = dom.createElement('li')
   li.className = 'nav-lang-' + lang
   li.innerHTML = '<a href="/' + (lang === 'en' ? '' : lang + '/') + (file === 'index.html' ? '' : file) + '" class="switch-lang" lang="' + lang + '">' + langName + '</a>'
   return li
@@ -125,6 +126,12 @@ cmdwatcher('build-html'
 			}
 		}
 		translations['en'] = original
+
+		var footer = dom.querySelector('footer')
+		if(footer) {
+			var footerHtml = Fs.readFileSync(FOOTER, 'utf8')
+			footer.innerHTML = footerHtml
+		}
 
 		var html = dom.querySelector('html')
 		var localeLinks = addLanguageLinks(dom, file, languages)


### PR DESCRIPTION
While working on #306 and #587 I realized that the footer is duplicated across all the html files. When I add the license link to the footer for #587, the license link was only added to index.html. Rather manually update the footer across all the html files, I decided to try to inject the footer as part of the build-html.js script.

Having read CONTRIBUTING.md, I realize the goal is to keep things simple. While using the build script to insert the header is less simple than having the footer duplicated, I think it's worth the extra complexity. But, if that's not the consensus, I can manually update the remaining footers to be consistent with the index.html changes made in #587 

I tested this by running "npm start" and confirmed the footer appeared. I did notice that this breaks the translation of the footer. I believe I can fix that, but I'd like to get buy in for this approach before investing more time in it.