### PR TITLE
remove talks section from about

### DIFF
--- a/about.html
+++ b/about.html
@@ -74,15 +74,6 @@
 
       <div class="container">
         <div class="third">
-          <h3 data-i18n="about-header-talk-title">Hear and see people talk</h3>
-        </div>
-        <div class="two-thirds">
-          <p data-i18n="about-info3">In <a href="https://archive.org/details/NodeUp55" target="_blank" rel="noreferrer noopener">episode 55</a> of the NodeUp podcast Mikeal Rogers, Max Ogden and other community members talk about NodeSchools. At Cascadia JS 2014 Jason Rhodes, from Baltimore, <a href="https://www.youtube.com/watch?v=YJ7txKTh3-E" target="_blank" rel="noreferrer noopener">talks about running NodeSchools</a>.</p>
-        </div>
-      </div>
-
-      <div class="container">
-        <div class="third">
           <h3 data-i18n="code-of-conduct">Code of conduct</h3>
         </div>
         <div class="two-thirds">


### PR DESCRIPTION
The video link doesn't work anymore, and the other one is outdated as well. I think we should just remove them. They're also all only in english and we'll not be able to keep this page updated.