### PR TITLE
standardize the code of scope-chains-closures workshopper

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,8 +453,7 @@
         <div id="scope-chains-closures" class="workshopper">
             <h4><a href="https://www.github.com/workshopper/scope-chains-closures" target="_blank" rel="noreferrer noopener">Scope Chains & Closures</a></h4>
             <p data-i18n="workshopper-scope-chains-closures">Learn the details of Scope, Scope Chains, Closures, and Garbage Collection.</p>
-            <code>npm i @workshoppers/scope-chains-closures -g</code><br>
-            <code>scope-chains-closures</code>
+            <code>npm install -g scope-chains-closures</code><br>
          </div>
       </div>
     </div>


### PR DESCRIPTION
- Change the npm install command to be the same as the other workshoppers
- Remove the starting command as it's not there for other (may be good to just add it everywhere)