### PR TITLE
npm start in ubuntu image

### DIFF
--- a/dockerFile
+++ b/dockerFile
@@ -1,9 +1,6 @@
 # Pull base image.
 FROM ubuntu
 
-# Set the working directory to /usr/src/app
-WORKDIR /usr/src/app
-
 # Update image
 RUN apt-get update
 
@@ -12,11 +9,18 @@ RUN apt-get install --yes curl
 RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install --yes nodejs
 
-# Bundle app source
-COPY . /usr/src/app
+# Set the working directory to /usr/src/app
+WORKDIR /usr/src/app
 
 # Install app dependencies
-RUN cd /usr/src/app; npm install && npm audit fix
+# A wildcard is used to ensure both package.json AND package-lock.json are copied where available (npm@5+)
+COPY package*.json ./
+
+# Bundle app source
+COPY . ./
+
+# Install app dependencies
+RUN npm install && npm audit fix
 
 # These commands unlike RUN (they are carried out in the construction of the container) are run when the container
 CMD ["npm", "start"]

--- a/dockerFile
+++ b/dockerFile
@@ -1,6 +1,9 @@
 # Pull base image.
 FROM ubuntu
 
+# Set the working directory to /usr/src/app
+WORKDIR /usr/src/app
+
 # Update image
 RUN apt-get update
 

--- a/dockerFile
+++ b/dockerFile
@@ -1,0 +1,19 @@
+# Pull base image.
+FROM ubuntu
+
+# Update image
+RUN apt-get update
+
+# Install Node.js
+RUN apt-get install --yes curl
+RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install --yes nodejs
+
+# Bundle app source
+COPY . /usr/src/app
+
+# Install app dependencies
+RUN cd /usr/src/app; npm install && npm audit fix
+
+# These commands unlike RUN (they are carried out in the construction of the container) are run when the container
+CMD ["npm", "start"]


### PR DESCRIPTION
Hi guy's
I'm windows user when i cloned project and install all dependencies with npm install and after installation is completed i run npm start it throw this error , **bash is not recognized as internal or external command** so i run npm start in docker container i have setup ubuntu image and install all dependencies and then run npm start it was running all scripts .