### PR TITLE
Update Git-it Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,9 +196,9 @@
             <code>npm install -g javascripting</code>
           </div>
           <div id="gitit" class="workshopper">
-            <h4><a class="js-workshop-link" href="https://www.github.com/jlord/git-it-electron" target="_blank" rel="noreferrer noopener">git-it</a></h4>
+            <h4><a class="js-workshop-link" href="https://github.com/Git-it-App/git-it-electron" target="_blank" rel="noreferrer noopener">Git-it</a></h4>
             <p data-i18n="workshopper-gitit">Learn Git and GitHub basics.</p>
-            <p>Download the <a href="https://github.com/jlord/git-it-electron/releases" target="_blank" rel="noreferrer noopener">latest desktop app release</a>.</p>
+            <p>Download the <a href="https://github.com/Git-it-App/git-it-electron/releases" target="_blank" rel="noreferrer noopener">latest desktop app release</a>.</p>
           </div>
           <div id="elementary-electron" class="workshopper">
             <h4><a class="js-workshop-link" href="https://www.github.com/maxogden/elementary-electron" target="_blank" rel="noreferrer noopener">Elementary Electron</a></h4>


### PR DESCRIPTION
As Git-it seems to be unmaintained, i took it over, updated it and now released a [Version 5.0.0](https://github.com/jotoeri/git-it-electron/releases/tag/v5.0.0). It would just have been a pity to not update this tool anymore.
Even that it looks a bit like i want to only move from jlord to my repo, i want to clarify, that this is not only self-promotion to the cost of Jessica Lord! All References to her as original Author are kept within the app, and i am still willing to move the repo back to her, if she wants. Just as there is now an updated Version of the app (and of course, as it was much of a work), i would like to spread the word a bit. ;)

Greets,
Jonas