### PR TITLE
fix broken map on landing page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -138,7 +138,7 @@ function makeMap(data) {
     + " target='_blank'>{{name}}</a><p>"
 
   var map = Sheetsee.loadMap("map")
-  Sheetsee.addTileLayer(map, 'jllord.n7aml2bc')
+  Sheetsee.addStyleLayer(map, 'mapbox://styles/mapbox/light-v10')
 
   var geoJSON = Sheetsee.createGeoJSON(sorted, optionsJSON)
   var markers = Sheetsee.addMarkerLayer(geoJSON, map, template)

--- a/js/sheetsee.js
+++ b/js/sheetsee.js
@@ -9991,8 +9991,8 @@ module.exports.loadMap = function(mapDiv) {
   return map
 }
 
-module.exports.addTileLayer = function(map, tileLayer) {
-  var layer = L.mapbox.tileLayer(tileLayer)
+module.exports.addStyleLayer = function(map, styleURL) {
+  var layer = L.mapbox.styleLayer(styleURL)
   layer.addTo(map)
 }
 


### PR DESCRIPTION
Currently, the map on the landing page is broken. This is because Mapbox recently turned off support for legacy style maps (for reference: https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4).

This update modifies the map implementation to rely on an `L.mapbox.styleLayer`﻿implementation, per the recommendation in https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/#mapboxjs-implementations. 
